### PR TITLE
feat(next): job polling proxy + Railway worker connection (closes #31)

### DIFF
--- a/bookbridge-next/lib/worker.ts
+++ b/bookbridge-next/lib/worker.ts
@@ -1,13 +1,10 @@
-const WORKER_URL = process.env.WORKER_URL || 'http://localhost:8000'
+const WORKER_URL = process.env.WORKER_URL || 'https://passionate-serenity-production-3cdd.up.railway.app'
 const TIMEOUT_MS = 8000
 
 export async function workerFetch(
   path: string,
   init?: RequestInit
 ): Promise<Response> {
-  if (process.env.NODE_ENV === 'production' && !process.env.WORKER_URL) {
-    throw new Error('Worker unavailable')
-  }
   try {
     return await fetch(`${WORKER_URL}${path}`, {
       ...init,


### PR DESCRIPTION
## Summary

- Implements `GET /api/jobs/[jobId]` polling proxy — authenticates via Clerk, checks ownership, proxies status from Worker (ref #31)
- Wires Railway worker URL as default fallback so Vercel can reach the Worker without `WORKER_URL` being set in the dashboard

## Changes

- `app/api/jobs/[jobId]/route.ts` — polling proxy with auth + ownership check
- `lib/worker.ts` — default URL points to live Railway endpoint; removed production guard that silently blocked all worker calls

## Test plan

- [ ] Upload a PDF on https://bookbridge-next.vercel.app — project should be created
- [ ] Click Translate on a chapter — job status should be polled from Railway worker
- [ ] `GET /api/jobs/[jobId]` returns 401 for unauthenticated requests
- [ ] `GET /api/jobs/[jobId]` returns 403 for jobs owned by another user

🤖 Generated with [Claude Code](https://claude.com/claude-code)