### PR TITLE
S3-7: Auth-aware landing page — conditional header + CTA redirect

### DIFF
--- a/bookbridge-next/__tests__/page.test.tsx
+++ b/bookbridge-next/__tests__/page.test.tsx
@@ -1,0 +1,86 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+
+// Must be hoisted before any imports that transitively touch @clerk/nextjs/server
+vi.mock('@clerk/nextjs/server', () => ({
+  auth: vi.fn(),
+}))
+
+// Mock the UserButton client component — it cannot render in jsdom
+vi.mock('@clerk/nextjs', () => ({
+  UserButton: () => <div data-testid="user-button" />,
+}))
+
+// Mock next/navigation so redirect() doesn't throw during render
+vi.mock('next/navigation', () => ({
+  redirect: vi.fn(),
+}))
+
+// Mock next/link so href is accessible in jsdom
+vi.mock('next/link', () => ({
+  default: ({ href, children }: { href: string; children: React.ReactNode }) => (
+    <a href={href}>{children}</a>
+  ),
+}))
+
+import { auth } from '@clerk/nextjs/server'
+const mockAuth = vi.mocked(auth)
+
+describe('app/page.tsx — auth-aware landing page', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.resetModules()
+  })
+
+  it('returns 200 and shows Sign In and Get Started links when signed out', async () => {
+    mockAuth.mockResolvedValueOnce(
+      { userId: null } as Awaited<ReturnType<typeof auth>>
+    )
+    const { default: Home } = await import('@/app/page')
+    const jsx = await Home()
+    render(jsx as React.ReactElement)
+
+    // auth() must be called so the page is conditionally rendered
+    expect(mockAuth).toHaveBeenCalledTimes(1)
+    expect(screen.getByText('Sign In')).toBeInTheDocument()
+    expect(screen.getByText('Get Started')).toBeInTheDocument()
+  })
+
+  it('does not show Sign In or Get Started links when signed in', async () => {
+    mockAuth.mockResolvedValueOnce(
+      { userId: 'user_abc' } as Awaited<ReturnType<typeof auth>>
+    )
+    const { default: Home } = await import('@/app/page')
+    const jsx = await Home()
+    render(jsx as React.ReactElement)
+
+    expect(screen.queryByText('Sign In')).not.toBeInTheDocument()
+    expect(screen.queryByText('Get Started')).not.toBeInTheDocument()
+  })
+
+  it('has Start Translating link pointing to /sign-up when signed out', async () => {
+    mockAuth.mockResolvedValueOnce(
+      { userId: null } as Awaited<ReturnType<typeof auth>>
+    )
+    const { default: Home } = await import('@/app/page')
+    const jsx = await Home()
+    render(jsx as React.ReactElement)
+
+    // auth() must be called so the CTA href is conditionally chosen
+    expect(mockAuth).toHaveBeenCalledTimes(1)
+    const cta = screen.getByRole('link', { name: /start translating/i })
+    expect(cta).toHaveAttribute('href', '/sign-up')
+  })
+
+  it('has Start Translating link pointing to /dashboard when signed in', async () => {
+    mockAuth.mockResolvedValueOnce(
+      { userId: 'user_abc' } as Awaited<ReturnType<typeof auth>>
+    )
+    const { default: Home } = await import('@/app/page')
+    const jsx = await Home()
+    render(jsx as React.ReactElement)
+
+    const cta = screen.getByRole('link', { name: /start translating/i })
+    expect(cta).toHaveAttribute('href', '/dashboard')
+  })
+})

--- a/bookbridge-next/__tests__/page.test.tsx
+++ b/bookbridge-next/__tests__/page.test.tsx
@@ -28,6 +28,7 @@ const mockAuth = vi.mocked(auth)
 
 describe('app/page.tsx — auth-aware landing page', () => {
   beforeEach(() => {
+    // resetModules + dynamic import() lets each test set a fresh mockResolvedValueOnce
     vi.clearAllMocks()
     vi.resetModules()
   })
@@ -56,6 +57,9 @@ describe('app/page.tsx — auth-aware landing page', () => {
 
     expect(screen.queryByText('Sign In')).not.toBeInTheDocument()
     expect(screen.queryByText('Get Started')).not.toBeInTheDocument()
+    const myLib = screen.getByRole('link', { name: /my library/i })
+    expect(myLib).toHaveAttribute('href', '/dashboard')
+    expect(screen.getByTestId('user-button')).toBeInTheDocument()
   })
 
   it('has Start Translating link pointing to /sign-up when signed out', async () => {
@@ -72,7 +76,7 @@ describe('app/page.tsx — auth-aware landing page', () => {
     expect(cta).toHaveAttribute('href', '/sign-up')
   })
 
-  it('has Start Translating link pointing to /dashboard when signed in', async () => {
+  it('has Go to Dashboard link pointing to /dashboard when signed in', async () => {
     mockAuth.mockResolvedValueOnce(
       { userId: 'user_abc' } as Awaited<ReturnType<typeof auth>>
     )
@@ -80,7 +84,7 @@ describe('app/page.tsx — auth-aware landing page', () => {
     const jsx = await Home()
     render(jsx as React.ReactElement)
 
-    const cta = screen.getByRole('link', { name: /start translating/i })
+    const cta = screen.getByRole('link', { name: /go to dashboard/i })
     expect(cta).toHaveAttribute('href', '/dashboard')
   })
 })

--- a/bookbridge-next/app/page.tsx
+++ b/bookbridge-next/app/page.tsx
@@ -1,6 +1,9 @@
 import Link from 'next/link'
+import { auth } from '@clerk/nextjs/server'
+import { UserButton } from '@clerk/nextjs'
 
-export default function Home() {
+export default async function Home() {
+  const { userId } = await auth()
   return (
     <div className="flex min-h-screen flex-col bg-cream">
       <header className="border-b border-parchment">
@@ -14,18 +17,32 @@ export default function Home() {
             </span>
           </div>
           <div className="flex items-center gap-4">
-            <Link
-              href="/sign-in"
-              className="text-sm font-medium text-ink-light hover:text-ink"
-            >
-              Sign In
-            </Link>
-            <Link
-              href="/sign-up"
-              className="rounded-lg bg-accent px-4 py-2 text-sm font-medium text-white hover:bg-accent-hover transition-colors"
-            >
-              Get Started
-            </Link>
+            {userId ? (
+              <>
+                <Link
+                  href="/dashboard"
+                  className="text-sm font-medium text-ink-light hover:text-ink"
+                >
+                  My Library
+                </Link>
+                <UserButton />
+              </>
+            ) : (
+              <>
+                <Link
+                  href="/sign-in"
+                  className="text-sm font-medium text-ink-light hover:text-ink"
+                >
+                  Sign In
+                </Link>
+                <Link
+                  href="/sign-up"
+                  className="rounded-lg bg-accent px-4 py-2 text-sm font-medium text-white hover:bg-accent-hover transition-colors"
+                >
+                  Get Started
+                </Link>
+              </>
+            )}
           </div>
         </div>
       </header>
@@ -49,7 +66,7 @@ export default function Home() {
               </p>
               <div className="mt-10 flex items-center gap-4">
                 <Link
-                  href="/sign-up"
+                  href={userId ? '/dashboard' : '/sign-up'}
                   className="rounded-lg bg-accent px-7 py-3.5 text-sm font-semibold text-white shadow-sm hover:bg-accent-hover transition-colors"
                 >
                   Start Translating

--- a/bookbridge-next/app/page.tsx
+++ b/bookbridge-next/app/page.tsx
@@ -69,7 +69,7 @@ export default async function Home() {
                   href={userId ? '/dashboard' : '/sign-up'}
                   className="rounded-lg bg-accent px-7 py-3.5 text-sm font-semibold text-white shadow-sm hover:bg-accent-hover transition-colors"
                 >
-                  Start Translating
+                  {userId ? 'Go to Dashboard' : 'Start Translating'}
                 </Link>
                 <Link
                   href="/read/demo"


### PR DESCRIPTION
## Summary
Closes #44

- `app/page.tsx` now calls `await auth()` server-side (no `'use client'`) to branch on `userId`
- Signed-in users see **My Library** + `<UserButton />` in the header instead of Sign In / Get Started
- **Start Translating** CTA routes to `/dashboard` and relabels to **Go to Dashboard** when signed in; unauthenticated path unchanged

## Acceptance Criteria
- [x] When signed in: header shows "My Library" link + `<UserButton />` instead of Sign In / Get Started
- [x] When signed in: "Start Translating" CTA navigates to `/dashboard`
- [x] When signed out: current UI unchanged (Sign In / Get Started / → `/sign-up`)
- [x] Fix is server-side using `auth()` — no `'use client'` added to `page.tsx`
- [x] TDD: `test(red):` commit with failing tests before implementation

## C.L.E.A.R. Self-Review
- [ ] **Correct** — logic is right, edge cases handled
- [ ] **Legible** — naming is clear, no magic numbers
- [ ] **Efficient** — no obvious performance issues
- [ ] **Abstracted** — no duplicated logic, helpers extracted where needed
- [ ] **Risk-aware** — no secrets in code, no SQL injection, OWASP top 10 considered

## AI Disclosure
- AI-generated: ~85%
- Tool used: Claude Code (claude-sonnet-4-6)
- Human review: yes — logic verified, tests checked manually