### PR TITLE
S3-4: BFF API — Projects CRUD (GET/PATCH/DELETE /api/projects/[id])

### DIFF
--- a/bookbridge-next/__tests__/api/dashboard-start-reading.test.tsx
+++ b/bookbridge-next/__tests__/api/dashboard-start-reading.test.tsx
@@ -55,6 +55,18 @@ vi.mock(
   })
 )
 
+// Mock DeleteProjectButton (client component — uses useRouter which is not mocked here)
+vi.mock(
+  '@/app/dashboard/projects/[id]/DeleteProjectButton',
+  () => ({
+    default: ({ projectId }: { projectId: string }) => (
+      <button data-testid="delete-project-btn" data-project={projectId}>
+        Delete
+      </button>
+    ),
+  })
+)
+
 const mockProjectFindUnique = vi.fn()
 
 vi.mock('@/lib/prisma', () => ({

--- a/bookbridge-next/__tests__/api/projects-id.test.ts
+++ b/bookbridge-next/__tests__/api/projects-id.test.ts
@@ -1,0 +1,290 @@
+/**
+ * Failing (red) tests for issue #29 — GET/PATCH/DELETE /api/projects/[id]
+ *
+ * Required by TDD red phase:
+ *   - test_patch_project_checks_ownership  — non-owner PATCH → 403
+ *   - test_delete_project_checks_ownership — non-owner DELETE → 403
+ *   - test_patch_validates_body_with_zod   — invalid PATCH body → 400
+ *
+ * Additional tests cover the remaining acceptance criteria:
+ *   - GET returns 401/403/404 per error matrix
+ *   - PATCH happy path (name/targetLanguage/style/isPublic update)
+ *   - DELETE cascades via Prisma (no explicit test needed beyond 204)
+ *   - All routes return 401 when unauthenticated (OWASP A07)
+ *
+ * The PATCH and DELETE handlers do not exist yet — every import of those
+ * named exports will be `undefined`, causing all related tests to fail.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { NextRequest } from 'next/server'
+
+vi.mock('@clerk/nextjs/server', () => ({
+  auth: vi.fn(),
+  clerkMiddleware: vi.fn(() => vi.fn()),
+  createRouteMatcher: vi.fn(() => vi.fn()),
+}))
+
+const mockProjectFindUnique = vi.fn()
+const mockProjectUpdate = vi.fn()
+const mockProjectDelete = vi.fn()
+
+vi.mock('@/lib/prisma', () => ({
+  default: {
+    project: {
+      findUnique: (...args: unknown[]) => mockProjectFindUnique(...args),
+      update: (...args: unknown[]) => mockProjectUpdate(...args),
+      delete: (...args: unknown[]) => mockProjectDelete(...args),
+    },
+  },
+}))
+
+import { auth } from '@clerk/nextjs/server'
+
+type AuthReturn = Awaited<ReturnType<typeof auth>>
+
+// ---------------------------------------------------------------------------
+// Test constants
+// ---------------------------------------------------------------------------
+const OWNER_ID = 'user_owner_abc'
+const OTHER_USER_ID = 'user_intruder_xyz'
+const PROJECT_ID = 'clh3p7b1p0001qzrmkf8g4m0i'
+
+const fakeProject = {
+  id: PROJECT_ID,
+  title: 'My Novel',
+  sourceFile: 'novel.pdf',
+  sourceLang: 'en',
+  targetLang: 'zh-Hans',
+  status: 'READY',
+  isPublic: false,
+  ownerId: OWNER_ID,
+  createdAt: new Date(),
+  updatedAt: new Date(),
+  chapters: [],
+  jobs: [],
+  glossary: [],
+}
+
+// ---------------------------------------------------------------------------
+// Request factory helpers
+// ---------------------------------------------------------------------------
+function makeParams(id: string) {
+  return { params: Promise.resolve({ id }) }
+}
+
+function makeGetRequest(id: string): NextRequest {
+  return new NextRequest(`http://localhost:3000/api/projects/${id}`, {
+    method: 'GET',
+  })
+}
+
+function makePatchRequest(id: string, body: Record<string, unknown>): NextRequest {
+  return new NextRequest(`http://localhost:3000/api/projects/${id}`, {
+    method: 'PATCH',
+    body: JSON.stringify(body),
+    headers: { 'Content-Type': 'application/json' },
+  })
+}
+
+function makeDeleteRequest(id: string): NextRequest {
+  return new NextRequest(`http://localhost:3000/api/projects/${id}`, {
+    method: 'DELETE',
+  })
+}
+
+// ---------------------------------------------------------------------------
+// Test suite
+// ---------------------------------------------------------------------------
+describe('GET /api/projects/[id]', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.resetModules()
+  })
+
+  // OWASP A07 — auth guard
+  it('returns 401 when user is not authenticated', async () => {
+    vi.mocked(auth).mockResolvedValueOnce({ userId: null } as AuthReturn)
+    const { GET } = await import('@/app/api/projects/[id]/route')
+    const res = await GET(makeGetRequest(PROJECT_ID), makeParams(PROJECT_ID))
+    expect(res.status).toBe(401)
+  })
+
+  // OWASP A01 — ownership check
+  it('returns 403 when the authenticated user does not own the project', async () => {
+    vi.mocked(auth).mockResolvedValueOnce({ userId: OTHER_USER_ID } as AuthReturn)
+    mockProjectFindUnique.mockResolvedValueOnce({ ...fakeProject, ownerId: OWNER_ID })
+    const { GET } = await import('@/app/api/projects/[id]/route')
+    const res = await GET(makeGetRequest(PROJECT_ID), makeParams(PROJECT_ID))
+    expect(res.status).toBe(403)
+  })
+
+  // Edge case — project not found
+  it('returns 404 when the project does not exist', async () => {
+    vi.mocked(auth).mockResolvedValueOnce({ userId: OWNER_ID } as AuthReturn)
+    mockProjectFindUnique.mockResolvedValueOnce(null)
+    const { GET } = await import('@/app/api/projects/[id]/route')
+    const res = await GET(makeGetRequest(PROJECT_ID), makeParams(PROJECT_ID))
+    expect(res.status).toBe(404)
+  })
+
+  // Happy path
+  it('returns 200 with project data for the owning user', async () => {
+    vi.mocked(auth).mockResolvedValueOnce({ userId: OWNER_ID } as AuthReturn)
+    mockProjectFindUnique.mockResolvedValueOnce(fakeProject)
+    const { GET } = await import('@/app/api/projects/[id]/route')
+    const res = await GET(makeGetRequest(PROJECT_ID), makeParams(PROJECT_ID))
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.data).toBeDefined()
+    expect(body.data.id).toBe(PROJECT_ID)
+  })
+})
+
+// ---------------------------------------------------------------------------
+describe('PATCH /api/projects/[id]', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.resetModules()
+  })
+
+  // OWASP A07 — auth guard
+  it('returns 401 when user is not authenticated', async () => {
+    vi.mocked(auth).mockResolvedValueOnce({ userId: null } as AuthReturn)
+    const { PATCH } = await import('@/app/api/projects/[id]/route')
+    const res = await PATCH(makePatchRequest(PROJECT_ID, { title: 'New Title' }), makeParams(PROJECT_ID))
+    expect(res.status).toBe(401)
+  })
+
+  // OWASP A01 — ownership check  (required: test_patch_project_checks_ownership)
+  it('returns 403 when authenticated non-owner calls PATCH', async () => {
+    vi.mocked(auth).mockResolvedValueOnce({ userId: OTHER_USER_ID } as AuthReturn)
+    mockProjectFindUnique.mockResolvedValueOnce({ ...fakeProject, ownerId: OWNER_ID })
+    const { PATCH } = await import('@/app/api/projects/[id]/route')
+    const res = await PATCH(
+      makePatchRequest(PROJECT_ID, { title: 'Stolen Title' }),
+      makeParams(PROJECT_ID),
+    )
+    expect(res.status).toBe(403)
+  })
+
+  // OWASP A03 — Zod validation  (required: test_patch_validates_body_with_zod)
+  it('returns 400 when PATCH body contains an invalid field type', async () => {
+    // isPublic must be boolean; sending a string should trigger Zod rejection
+    vi.mocked(auth).mockResolvedValueOnce({ userId: OWNER_ID } as AuthReturn)
+    mockProjectFindUnique.mockResolvedValueOnce(fakeProject)
+    const { PATCH } = await import('@/app/api/projects/[id]/route')
+    const res = await PATCH(
+      makePatchRequest(PROJECT_ID, { isPublic: 'yes' }),  // wrong type
+      makeParams(PROJECT_ID),
+    )
+    expect(res.status).toBe(400)
+  })
+
+  // OWASP A03 — Zod validation rejects unknown fields when schema is strict
+  it('returns 400 when PATCH body contains only unknown/extra fields', async () => {
+    vi.mocked(auth).mockResolvedValueOnce({ userId: OWNER_ID } as AuthReturn)
+    mockProjectFindUnique.mockResolvedValueOnce(fakeProject)
+    const { PATCH } = await import('@/app/api/projects/[id]/route')
+    const res = await PATCH(
+      makePatchRequest(PROJECT_ID, { nonExistentField: 'value' }),
+      makeParams(PROJECT_ID),
+    )
+    // Either 400 (strict schema) or the field is silently stripped — the key
+    // guarantee is that a body with ONLY an unknown field and no valid field
+    // never produces a 200 update of nothing.  Strict Zod (strip vs. strict)
+    // will return 400.
+    expect(res.status).toBe(400)
+  })
+
+  // Edge case — project not found before ownership check ordering
+  it('returns 404 when the project does not exist', async () => {
+    vi.mocked(auth).mockResolvedValueOnce({ userId: OWNER_ID } as AuthReturn)
+    mockProjectFindUnique.mockResolvedValueOnce(null)
+    const { PATCH } = await import('@/app/api/projects/[id]/route')
+    const res = await PATCH(
+      makePatchRequest(PROJECT_ID, { title: 'New Title' }),
+      makeParams(PROJECT_ID),
+    )
+    expect(res.status).toBe(404)
+  })
+
+  // Happy path — update title/targetLanguage/style
+  it('returns updated project when owner sends a valid PATCH body', async () => {
+    vi.mocked(auth).mockResolvedValueOnce({ userId: OWNER_ID } as AuthReturn)
+    mockProjectFindUnique.mockResolvedValueOnce(fakeProject)
+    const updatedProject = { ...fakeProject, title: 'New Title', targetLang: 'ja' }
+    mockProjectUpdate.mockResolvedValueOnce(updatedProject)
+    const { PATCH } = await import('@/app/api/projects/[id]/route')
+    const res = await PATCH(
+      makePatchRequest(PROJECT_ID, { name: 'New Title', targetLanguage: 'ja' }),
+      makeParams(PROJECT_ID),
+    )
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.id).toBe(PROJECT_ID)
+  })
+
+  // Happy path — isPublic toggle
+  it('returns updated project when owner toggles isPublic to true', async () => {
+    vi.mocked(auth).mockResolvedValueOnce({ userId: OWNER_ID } as AuthReturn)
+    mockProjectFindUnique.mockResolvedValueOnce(fakeProject)
+    const updatedProject = { ...fakeProject, isPublic: true }
+    mockProjectUpdate.mockResolvedValueOnce(updatedProject)
+    const { PATCH } = await import('@/app/api/projects/[id]/route')
+    const res = await PATCH(
+      makePatchRequest(PROJECT_ID, { isPublic: true }),
+      makeParams(PROJECT_ID),
+    )
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.isPublic).toBe(true)
+  })
+})
+
+// ---------------------------------------------------------------------------
+describe('DELETE /api/projects/[id]', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.resetModules()
+  })
+
+  // OWASP A07 — auth guard
+  it('returns 401 when user is not authenticated', async () => {
+    vi.mocked(auth).mockResolvedValueOnce({ userId: null } as AuthReturn)
+    const { DELETE } = await import('@/app/api/projects/[id]/route')
+    const res = await DELETE(makeDeleteRequest(PROJECT_ID), makeParams(PROJECT_ID))
+    expect(res.status).toBe(401)
+  })
+
+  // OWASP A01 — ownership check  (required: test_delete_project_checks_ownership)
+  it('returns 403 when authenticated non-owner calls DELETE', async () => {
+    vi.mocked(auth).mockResolvedValueOnce({ userId: OTHER_USER_ID } as AuthReturn)
+    mockProjectFindUnique.mockResolvedValueOnce({ ...fakeProject, ownerId: OWNER_ID })
+    const { DELETE } = await import('@/app/api/projects/[id]/route')
+    const res = await DELETE(makeDeleteRequest(PROJECT_ID), makeParams(PROJECT_ID))
+    expect(res.status).toBe(403)
+  })
+
+  // Edge case — project not found
+  it('returns 404 when the project does not exist', async () => {
+    vi.mocked(auth).mockResolvedValueOnce({ userId: OWNER_ID } as AuthReturn)
+    mockProjectFindUnique.mockResolvedValueOnce(null)
+    const { DELETE } = await import('@/app/api/projects/[id]/route')
+    const res = await DELETE(makeDeleteRequest(PROJECT_ID), makeParams(PROJECT_ID))
+    expect(res.status).toBe(404)
+  })
+
+  // Happy path — delete cascades via Prisma schema (onDelete: Cascade on Chapter/Job)
+  it('returns 204 and calls prisma.project.delete for the owning user', async () => {
+    vi.mocked(auth).mockResolvedValueOnce({ userId: OWNER_ID } as AuthReturn)
+    mockProjectFindUnique.mockResolvedValueOnce(fakeProject)
+    mockProjectDelete.mockResolvedValueOnce(fakeProject)
+    const { DELETE } = await import('@/app/api/projects/[id]/route')
+    const res = await DELETE(makeDeleteRequest(PROJECT_ID), makeParams(PROJECT_ID))
+    expect(res.status).toBe(204)
+    expect(mockProjectDelete).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { id: PROJECT_ID } })
+    )
+  })
+})

--- a/bookbridge-next/__tests__/api/projects-id.test.ts
+++ b/bookbridge-next/__tests__/api/projects-id.test.ts
@@ -18,6 +18,7 @@
 
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { NextRequest } from 'next/server'
+import { Prisma } from '@/app/generated/prisma/client'
 
 vi.mock('@clerk/nextjs/server', () => ({
   auth: vi.fn(),
@@ -50,20 +51,33 @@ const OWNER_ID = 'user_owner_abc'
 const OTHER_USER_ID = 'user_intruder_xyz'
 const PROJECT_ID = 'clh3p7b1p0001qzrmkf8g4m0i'
 
-const fakeProject = {
+// Slim shape returned by requireProjectOwner's `select: { id, ownerId }`.
+const fakeProjectSlim = {
   id: PROJECT_ID,
+  ownerId: OWNER_ID,
+}
+
+// Full shape returned by GET's findUnique with includes.
+const fakeProject = {
+  ...fakeProjectSlim,
   title: 'My Novel',
   sourceFile: 'novel.pdf',
   sourceLang: 'en',
   targetLang: 'zh-Hans',
   status: 'READY',
   isPublic: false,
-  ownerId: OWNER_ID,
   createdAt: new Date(),
   updatedAt: new Date(),
   chapters: [],
   jobs: [],
   glossary: [],
+}
+
+function makeP2025(): Prisma.PrismaClientKnownRequestError {
+  return new Prisma.PrismaClientKnownRequestError(
+    'Record to update not found',
+    { code: 'P2025', clientVersion: '7.7.0' },
+  )
 }
 
 // ---------------------------------------------------------------------------
@@ -159,7 +173,7 @@ describe('PATCH /api/projects/[id]', () => {
   // OWASP A01 — ownership check  (required: test_patch_project_checks_ownership)
   it('returns 403 when authenticated non-owner calls PATCH', async () => {
     vi.mocked(auth).mockResolvedValueOnce({ userId: OTHER_USER_ID } as AuthReturn)
-    mockProjectFindUnique.mockResolvedValueOnce({ ...fakeProject, ownerId: OWNER_ID })
+    mockProjectFindUnique.mockResolvedValueOnce(fakeProjectSlim)
     const { PATCH } = await import('@/app/api/projects/[id]/route')
     const res = await PATCH(
       makePatchRequest(PROJECT_ID, { title: 'Stolen Title' }),
@@ -169,32 +183,43 @@ describe('PATCH /api/projects/[id]', () => {
   })
 
   // OWASP A03 — Zod validation  (required: test_patch_validates_body_with_zod)
-  it('returns 400 when PATCH body contains an invalid field type', async () => {
+  it('returns 400 with details when PATCH body contains an invalid field type', async () => {
     // isPublic must be boolean; sending a string should trigger Zod rejection
     vi.mocked(auth).mockResolvedValueOnce({ userId: OWNER_ID } as AuthReturn)
-    mockProjectFindUnique.mockResolvedValueOnce(fakeProject)
+    mockProjectFindUnique.mockResolvedValueOnce(fakeProjectSlim)
     const { PATCH } = await import('@/app/api/projects/[id]/route')
     const res = await PATCH(
       makePatchRequest(PROJECT_ID, { isPublic: 'yes' }),  // wrong type
       makeParams(PROJECT_ID),
     )
     expect(res.status).toBe(400)
+    const body = await res.json()
+    expect(body.error).toBe('Invalid request body')
+    // Surface Zod's structured field errors (review #6) — no PII, just field names.
+    expect(body.details).toBeDefined()
+    expect(body.details.isPublic).toBeDefined()
   })
 
   // OWASP A03 — Zod validation rejects unknown fields when schema is strict
   it('returns 400 when PATCH body contains only unknown/extra fields', async () => {
     vi.mocked(auth).mockResolvedValueOnce({ userId: OWNER_ID } as AuthReturn)
-    mockProjectFindUnique.mockResolvedValueOnce(fakeProject)
+    mockProjectFindUnique.mockResolvedValueOnce(fakeProjectSlim)
     const { PATCH } = await import('@/app/api/projects/[id]/route')
     const res = await PATCH(
       makePatchRequest(PROJECT_ID, { nonExistentField: 'value' }),
       makeParams(PROJECT_ID),
     )
-    // Either 400 (strict schema) or the field is silently stripped — the key
-    // guarantee is that a body with ONLY an unknown field and no valid field
-    // never produces a 200 update of nothing.  Strict Zod (strip vs. strict)
-    // will return 400.
     expect(res.status).toBe(400)
+  })
+
+  // Review #1 — empty body must not reach Prisma as a no-op UPDATE
+  it('returns 400 when PATCH body is empty after mapping', async () => {
+    vi.mocked(auth).mockResolvedValueOnce({ userId: OWNER_ID } as AuthReturn)
+    mockProjectFindUnique.mockResolvedValueOnce(fakeProjectSlim)
+    const { PATCH } = await import('@/app/api/projects/[id]/route')
+    const res = await PATCH(makePatchRequest(PROJECT_ID, {}), makeParams(PROJECT_ID))
+    expect(res.status).toBe(400)
+    expect(mockProjectUpdate).not.toHaveBeenCalled()
   })
 
   // Edge case — project not found before ownership check ordering
@@ -209,10 +234,23 @@ describe('PATCH /api/projects/[id]', () => {
     expect(res.status).toBe(404)
   })
 
-  // Happy path — update title/targetLanguage/style
-  it('returns updated project when owner sends a valid PATCH body', async () => {
+  // Review #2 — P2025 from a racing delete must become a 404, not a 500
+  it('returns 404 when prisma.project.update throws P2025 (concurrent delete)', async () => {
     vi.mocked(auth).mockResolvedValueOnce({ userId: OWNER_ID } as AuthReturn)
-    mockProjectFindUnique.mockResolvedValueOnce(fakeProject)
+    mockProjectFindUnique.mockResolvedValueOnce(fakeProjectSlim)
+    mockProjectUpdate.mockRejectedValueOnce(makeP2025())
+    const { PATCH } = await import('@/app/api/projects/[id]/route')
+    const res = await PATCH(
+      makePatchRequest(PROJECT_ID, { name: 'New Title' }),
+      makeParams(PROJECT_ID),
+    )
+    expect(res.status).toBe(404)
+  })
+
+  // Happy path — update title/targetLanguage (wrapped in { data: ... } to match GET)
+  it('returns updated project in { data } envelope when owner sends a valid PATCH body', async () => {
+    vi.mocked(auth).mockResolvedValueOnce({ userId: OWNER_ID } as AuthReturn)
+    mockProjectFindUnique.mockResolvedValueOnce(fakeProjectSlim)
     const updatedProject = { ...fakeProject, title: 'New Title', targetLang: 'ja' }
     mockProjectUpdate.mockResolvedValueOnce(updatedProject)
     const { PATCH } = await import('@/app/api/projects/[id]/route')
@@ -222,13 +260,14 @@ describe('PATCH /api/projects/[id]', () => {
     )
     expect(res.status).toBe(200)
     const body = await res.json()
-    expect(body.id).toBe(PROJECT_ID)
+    expect(body.data).toBeDefined()
+    expect(body.data.id).toBe(PROJECT_ID)
   })
 
   // Happy path — isPublic toggle
   it('returns updated project when owner toggles isPublic to true', async () => {
     vi.mocked(auth).mockResolvedValueOnce({ userId: OWNER_ID } as AuthReturn)
-    mockProjectFindUnique.mockResolvedValueOnce(fakeProject)
+    mockProjectFindUnique.mockResolvedValueOnce(fakeProjectSlim)
     const updatedProject = { ...fakeProject, isPublic: true }
     mockProjectUpdate.mockResolvedValueOnce(updatedProject)
     const { PATCH } = await import('@/app/api/projects/[id]/route')
@@ -238,7 +277,7 @@ describe('PATCH /api/projects/[id]', () => {
     )
     expect(res.status).toBe(200)
     const body = await res.json()
-    expect(body.isPublic).toBe(true)
+    expect(body.data.isPublic).toBe(true)
   })
 })
 
@@ -260,7 +299,7 @@ describe('DELETE /api/projects/[id]', () => {
   // OWASP A01 — ownership check  (required: test_delete_project_checks_ownership)
   it('returns 403 when authenticated non-owner calls DELETE', async () => {
     vi.mocked(auth).mockResolvedValueOnce({ userId: OTHER_USER_ID } as AuthReturn)
-    mockProjectFindUnique.mockResolvedValueOnce({ ...fakeProject, ownerId: OWNER_ID })
+    mockProjectFindUnique.mockResolvedValueOnce(fakeProjectSlim)
     const { DELETE } = await import('@/app/api/projects/[id]/route')
     const res = await DELETE(makeDeleteRequest(PROJECT_ID), makeParams(PROJECT_ID))
     expect(res.status).toBe(403)
@@ -275,10 +314,20 @@ describe('DELETE /api/projects/[id]', () => {
     expect(res.status).toBe(404)
   })
 
+  // Review #2 — P2025 from a racing delete must become a 404, not a 500
+  it('returns 404 when prisma.project.delete throws P2025 (concurrent delete)', async () => {
+    vi.mocked(auth).mockResolvedValueOnce({ userId: OWNER_ID } as AuthReturn)
+    mockProjectFindUnique.mockResolvedValueOnce(fakeProjectSlim)
+    mockProjectDelete.mockRejectedValueOnce(makeP2025())
+    const { DELETE } = await import('@/app/api/projects/[id]/route')
+    const res = await DELETE(makeDeleteRequest(PROJECT_ID), makeParams(PROJECT_ID))
+    expect(res.status).toBe(404)
+  })
+
   // Happy path — delete cascades via Prisma schema (onDelete: Cascade on Chapter/Job)
   it('returns 204 and calls prisma.project.delete for the owning user', async () => {
     vi.mocked(auth).mockResolvedValueOnce({ userId: OWNER_ID } as AuthReturn)
-    mockProjectFindUnique.mockResolvedValueOnce(fakeProject)
+    mockProjectFindUnique.mockResolvedValueOnce(fakeProjectSlim)
     mockProjectDelete.mockResolvedValueOnce(fakeProject)
     const { DELETE } = await import('@/app/api/projects/[id]/route')
     const res = await DELETE(makeDeleteRequest(PROJECT_ID), makeParams(PROJECT_ID))

--- a/bookbridge-next/__tests__/delete-project-button.test.tsx
+++ b/bookbridge-next/__tests__/delete-project-button.test.tsx
@@ -1,0 +1,124 @@
+/**
+ * Failing (red) tests for the DeleteProjectButton UI wiring.
+ *
+ * Context: PR #55 (issue #29) shipped DELETE /api/projects/[id]. The library
+ * and project-detail pages still have no way to invoke it. This component
+ * adds a two-step inline confirm ("Delete" → "Cancel | Confirm delete") and
+ * calls the endpoint, then redirects to /dashboard on success.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+
+const mockPush = vi.fn()
+vi.mock('next/navigation', () => ({
+  useRouter: vi.fn(() => ({ push: mockPush, refresh: vi.fn() })),
+}))
+
+vi.mock('lucide-react', () => ({
+  Trash2: () => <svg data-testid="trash-icon" />,
+  Loader2: () => <svg data-testid="loader-icon" />,
+}))
+
+import DeleteProjectButton from '@/app/dashboard/projects/[id]/DeleteProjectButton'
+
+const PROJECT_ID = 'clh3p7b1p0001qzrmkf8g4m0i'
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  // @ts-expect-error overriding global.fetch for the test
+  global.fetch = vi.fn()
+})
+
+describe('DeleteProjectButton — initial state', () => {
+  it('renders a single Delete button by default (no confirmation visible yet)', () => {
+    render(<DeleteProjectButton projectId={PROJECT_ID} />)
+    expect(screen.getByRole('button', { name: /^delete$/i })).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /confirm delete/i })).not.toBeInTheDocument()
+  })
+
+  it('does not call fetch on initial render', () => {
+    render(<DeleteProjectButton projectId={PROJECT_ID} />)
+    expect(global.fetch).not.toHaveBeenCalled()
+  })
+})
+
+describe('DeleteProjectButton — confirm flow', () => {
+  it('clicking Delete reveals Cancel and Confirm delete buttons', () => {
+    render(<DeleteProjectButton projectId={PROJECT_ID} />)
+    fireEvent.click(screen.getByRole('button', { name: /^delete$/i }))
+    expect(screen.getByRole('button', { name: /^cancel$/i })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /confirm delete/i })).toBeInTheDocument()
+  })
+
+  it('Cancel returns to initial state and does not call fetch', () => {
+    render(<DeleteProjectButton projectId={PROJECT_ID} />)
+    fireEvent.click(screen.getByRole('button', { name: /^delete$/i }))
+    fireEvent.click(screen.getByRole('button', { name: /^cancel$/i }))
+    expect(screen.getByRole('button', { name: /^delete$/i })).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /confirm delete/i })).not.toBeInTheDocument()
+    expect(global.fetch).not.toHaveBeenCalled()
+  })
+})
+
+describe('DeleteProjectButton — API call', () => {
+  it('Confirm delete sends DELETE to /api/projects/[id]', async () => {
+    vi.mocked(global.fetch).mockResolvedValueOnce(
+      new Response(null, { status: 204 }),
+    )
+    render(<DeleteProjectButton projectId={PROJECT_ID} />)
+    fireEvent.click(screen.getByRole('button', { name: /^delete$/i }))
+    fireEvent.click(screen.getByRole('button', { name: /confirm delete/i }))
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledWith(
+        `/api/projects/${PROJECT_ID}`,
+        expect.objectContaining({ method: 'DELETE' }),
+      )
+    })
+  })
+
+  it('on 204 success, redirects to /dashboard', async () => {
+    vi.mocked(global.fetch).mockResolvedValueOnce(
+      new Response(null, { status: 204 }),
+    )
+    render(<DeleteProjectButton projectId={PROJECT_ID} />)
+    fireEvent.click(screen.getByRole('button', { name: /^delete$/i }))
+    fireEvent.click(screen.getByRole('button', { name: /confirm delete/i }))
+    await waitFor(() => {
+      expect(mockPush).toHaveBeenCalledWith('/dashboard')
+    })
+  })
+})
+
+describe('DeleteProjectButton — error handling', () => {
+  it('shows an error message and stays on the page on 403', async () => {
+    vi.mocked(global.fetch).mockResolvedValueOnce(
+      new Response(JSON.stringify({ error: 'Forbidden' }), { status: 403 }),
+    )
+    render(<DeleteProjectButton projectId={PROJECT_ID} />)
+    fireEvent.click(screen.getByRole('button', { name: /^delete$/i }))
+    fireEvent.click(screen.getByRole('button', { name: /confirm delete/i }))
+    expect(await screen.findByRole('alert')).toBeInTheDocument()
+    expect(mockPush).not.toHaveBeenCalled()
+  })
+
+  it('shows an error message on 404', async () => {
+    vi.mocked(global.fetch).mockResolvedValueOnce(
+      new Response(JSON.stringify({ error: 'Not found' }), { status: 404 }),
+    )
+    render(<DeleteProjectButton projectId={PROJECT_ID} />)
+    fireEvent.click(screen.getByRole('button', { name: /^delete$/i }))
+    fireEvent.click(screen.getByRole('button', { name: /confirm delete/i }))
+    expect(await screen.findByRole('alert')).toBeInTheDocument()
+    expect(mockPush).not.toHaveBeenCalled()
+  })
+
+  it('shows an error message when fetch rejects (network error)', async () => {
+    vi.mocked(global.fetch).mockRejectedValueOnce(new Error('network down'))
+    render(<DeleteProjectButton projectId={PROJECT_ID} />)
+    fireEvent.click(screen.getByRole('button', { name: /^delete$/i }))
+    fireEvent.click(screen.getByRole('button', { name: /confirm delete/i }))
+    expect(await screen.findByRole('alert')).toBeInTheDocument()
+    expect(mockPush).not.toHaveBeenCalled()
+  })
+})

--- a/bookbridge-next/__tests__/delete-project-button.test.tsx
+++ b/bookbridge-next/__tests__/delete-project-button.test.tsx
@@ -26,7 +26,6 @@ const PROJECT_ID = 'clh3p7b1p0001qzrmkf8g4m0i'
 
 beforeEach(() => {
   vi.clearAllMocks()
-  // @ts-expect-error overriding global.fetch for the test
   global.fetch = vi.fn()
 })
 

--- a/bookbridge-next/app/api/projects/[id]/route.ts
+++ b/bookbridge-next/app/api/projects/[id]/route.ts
@@ -2,6 +2,7 @@ import { auth } from '@clerk/nextjs/server'
 import { NextRequest, NextResponse } from 'next/server'
 import { z } from 'zod'
 import prisma from '@/lib/prisma'
+import { requireProjectOwner } from '@/lib/project-auth'
 
 const patchSchema = z
   .object({
@@ -50,16 +51,8 @@ export async function PATCH(
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
   }
 
-  const project = await prisma.project.findUnique({
-    where: { id },
-    select: { id: true, ownerId: true },
-  })
-  if (!project) {
-    return NextResponse.json({ error: 'Not found' }, { status: 404 })
-  }
-  if (project.ownerId !== userId) {
-    return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
-  }
+  const guard = await requireProjectOwner(id, userId)
+  if (!guard.ok) return guard.response
 
   let raw: unknown
   try {
@@ -92,16 +85,8 @@ export async function DELETE(
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
   }
 
-  const project = await prisma.project.findUnique({
-    where: { id },
-    select: { id: true, ownerId: true },
-  })
-  if (!project) {
-    return NextResponse.json({ error: 'Not found' }, { status: 404 })
-  }
-  if (project.ownerId !== userId) {
-    return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
-  }
+  const guard = await requireProjectOwner(id, userId)
+  if (!guard.ok) return guard.response
 
   await prisma.project.delete({ where: { id } })
   return new NextResponse(null, { status: 204 })

--- a/bookbridge-next/app/api/projects/[id]/route.ts
+++ b/bookbridge-next/app/api/projects/[id]/route.ts
@@ -1,8 +1,13 @@
 import { auth } from '@clerk/nextjs/server'
 import { NextRequest, NextResponse } from 'next/server'
 import { z } from 'zod'
+import { Prisma } from '@/app/generated/prisma/client'
 import prisma from '@/lib/prisma'
 import { requireProjectOwner } from '@/lib/project-auth'
+
+function isRecordNotFound(err: unknown): boolean {
+  return err instanceof Prisma.PrismaClientKnownRequestError && err.code === 'P2025'
+}
 
 const patchSchema = z
   .object({
@@ -63,7 +68,13 @@ export async function PATCH(
 
   const parsed = patchSchema.safeParse(raw)
   if (!parsed.success) {
-    return NextResponse.json({ error: 'Invalid request body' }, { status: 400 })
+    return NextResponse.json(
+      {
+        error: 'Invalid request body',
+        details: parsed.error.flatten().fieldErrors,
+      },
+      { status: 400 },
+    )
   }
 
   const data: { title?: string; targetLang?: string; isPublic?: boolean } = {}
@@ -71,8 +82,23 @@ export async function PATCH(
   if (parsed.data.targetLanguage !== undefined) data.targetLang = parsed.data.targetLanguage
   if (parsed.data.isPublic !== undefined) data.isPublic = parsed.data.isPublic
 
-  const updated = await prisma.project.update({ where: { id }, data })
-  return NextResponse.json(updated)
+  if (Object.keys(data).length === 0) {
+    return NextResponse.json(
+      { error: 'At least one updatable field is required' },
+      { status: 400 },
+    )
+  }
+
+  try {
+    const updated = await prisma.project.update({ where: { id }, data })
+    return NextResponse.json({ data: updated })
+  } catch (err) {
+    // TOCTOU: project may be deleted between the guard's findUnique and this update.
+    if (isRecordNotFound(err)) {
+      return NextResponse.json({ error: 'Not found' }, { status: 404 })
+    }
+    throw err
+  }
 }
 
 export async function DELETE(
@@ -88,6 +114,13 @@ export async function DELETE(
   const guard = await requireProjectOwner(id, userId)
   if (!guard.ok) return guard.response
 
-  await prisma.project.delete({ where: { id } })
+  try {
+    await prisma.project.delete({ where: { id } })
+  } catch (err) {
+    if (isRecordNotFound(err)) {
+      return NextResponse.json({ error: 'Not found' }, { status: 404 })
+    }
+    throw err
+  }
   return new NextResponse(null, { status: 204 })
 }

--- a/bookbridge-next/app/api/projects/[id]/route.ts
+++ b/bookbridge-next/app/api/projects/[id]/route.ts
@@ -1,6 +1,15 @@
 import { auth } from '@clerk/nextjs/server'
 import { NextRequest, NextResponse } from 'next/server'
+import { z } from 'zod'
 import prisma from '@/lib/prisma'
+
+const patchSchema = z
+  .object({
+    name: z.string().min(1).optional(),
+    targetLanguage: z.string().min(1).optional(),
+    isPublic: z.boolean().optional(),
+  })
+  .strict()
 
 export async function GET(
   _req: NextRequest,
@@ -29,4 +38,71 @@ export async function GET(
   }
 
   return NextResponse.json({ data: project })
+}
+
+export async function PATCH(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const { id } = await params
+  const { userId } = await auth()
+  if (!userId) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const project = await prisma.project.findUnique({
+    where: { id },
+    select: { id: true, ownerId: true },
+  })
+  if (!project) {
+    return NextResponse.json({ error: 'Not found' }, { status: 404 })
+  }
+  if (project.ownerId !== userId) {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+  }
+
+  let raw: unknown
+  try {
+    raw = await req.json()
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 })
+  }
+
+  const parsed = patchSchema.safeParse(raw)
+  if (!parsed.success) {
+    return NextResponse.json({ error: 'Invalid request body' }, { status: 400 })
+  }
+
+  const data: { title?: string; targetLang?: string; isPublic?: boolean } = {}
+  if (parsed.data.name !== undefined) data.title = parsed.data.name
+  if (parsed.data.targetLanguage !== undefined) data.targetLang = parsed.data.targetLanguage
+  if (parsed.data.isPublic !== undefined) data.isPublic = parsed.data.isPublic
+
+  const updated = await prisma.project.update({ where: { id }, data })
+  return NextResponse.json(updated)
+}
+
+export async function DELETE(
+  _req: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const { id } = await params
+  const { userId } = await auth()
+  if (!userId) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const project = await prisma.project.findUnique({
+    where: { id },
+    select: { id: true, ownerId: true },
+  })
+  if (!project) {
+    return NextResponse.json({ error: 'Not found' }, { status: 404 })
+  }
+  if (project.ownerId !== userId) {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+  }
+
+  await prisma.project.delete({ where: { id } })
+  return new NextResponse(null, { status: 204 })
 }

--- a/bookbridge-next/app/dashboard/projects/[id]/DeleteProjectButton.tsx
+++ b/bookbridge-next/app/dashboard/projects/[id]/DeleteProjectButton.tsx
@@ -1,0 +1,83 @@
+'use client'
+
+import { useState } from 'react'
+import { useRouter } from 'next/navigation'
+import { Trash2, Loader2 } from 'lucide-react'
+
+type Phase = 'idle' | 'confirming' | 'deleting'
+
+export default function DeleteProjectButton({ projectId }: { projectId: string }) {
+  const router = useRouter()
+  const [phase, setPhase] = useState<Phase>('idle')
+  const [errorMsg, setErrorMsg] = useState<string | null>(null)
+
+  async function handleConfirm() {
+    setPhase('deleting')
+    setErrorMsg(null)
+    try {
+      const res = await fetch(`/api/projects/${projectId}`, { method: 'DELETE' })
+      if (!res.ok) {
+        let message = 'Failed to delete project. Please try again.'
+        try {
+          const body = (await res.json()) as { error?: string }
+          if (body?.error) message = body.error
+        } catch {
+          // non-JSON response — keep generic message
+        }
+        setErrorMsg(message)
+        setPhase('confirming')
+        return
+      }
+      router.push('/dashboard')
+    } catch {
+      setErrorMsg('Network error. Please try again.')
+      setPhase('confirming')
+    }
+  }
+
+  if (phase === 'idle') {
+    return (
+      <button
+        onClick={() => setPhase('confirming')}
+        className="flex items-center gap-1 rounded-lg border border-red-300 px-4 py-2 text-sm font-medium text-red-700 hover:bg-red-50 dark:border-red-900 dark:text-red-400 dark:hover:bg-red-950"
+      >
+        <Trash2 className="h-4 w-4" />
+        Delete
+      </button>
+    )
+  }
+
+  return (
+    <div className="flex flex-col items-end gap-1">
+      <div className="flex gap-2">
+        <button
+          onClick={() => {
+            setPhase('idle')
+            setErrorMsg(null)
+          }}
+          disabled={phase === 'deleting'}
+          className="rounded-lg border border-zinc-300 px-4 py-2 text-sm font-medium hover:bg-zinc-100 disabled:opacity-50 dark:border-zinc-700 dark:hover:bg-zinc-900"
+        >
+          Cancel
+        </button>
+        <button
+          onClick={handleConfirm}
+          disabled={phase === 'deleting'}
+          className="flex items-center gap-1 rounded-lg bg-red-600 px-4 py-2 text-sm font-medium text-white hover:bg-red-700 disabled:opacity-50"
+        >
+          {phase === 'deleting' ? (
+            <Loader2 className="h-4 w-4 animate-spin" />
+          ) : (
+            <Trash2 className="h-4 w-4" />
+          )}
+          Confirm delete
+        </button>
+      </div>
+      {errorMsg && (
+        <p role="alert" className="text-xs text-red-600">
+          {errorMsg}
+        </p>
+      )}
+    </div>
+  )
+}

--- a/bookbridge-next/app/dashboard/projects/[id]/page.tsx
+++ b/bookbridge-next/app/dashboard/projects/[id]/page.tsx
@@ -4,6 +4,7 @@ import Link from 'next/link'
 import prisma from '@/lib/prisma'
 import { FileText, BookOpen, ArrowLeft } from 'lucide-react'
 import TranslateButton from './TranslateButton'
+import DeleteProjectButton from './DeleteProjectButton'
 
 export default async function ProjectPage({
   params,
@@ -60,6 +61,7 @@ export default async function ProjectPage({
               Start Reading
             </Link>
           )}
+          <DeleteProjectButton projectId={project.id} />
         </div>
       </div>
 

--- a/bookbridge-next/lib/project-auth.ts
+++ b/bookbridge-next/lib/project-auth.ts
@@ -1,0 +1,23 @@
+import { NextResponse } from 'next/server'
+import prisma from '@/lib/prisma'
+
+type GuardResult =
+  | { ok: true }
+  | { ok: false; response: NextResponse }
+
+export async function requireProjectOwner(
+  projectId: string,
+  userId: string,
+): Promise<GuardResult> {
+  const project = await prisma.project.findUnique({
+    where: { id: projectId },
+    select: { id: true, ownerId: true },
+  })
+  if (!project) {
+    return { ok: false, response: NextResponse.json({ error: 'Not found' }, { status: 404 }) }
+  }
+  if (project.ownerId !== userId) {
+    return { ok: false, response: NextResponse.json({ error: 'Forbidden' }, { status: 403 }) }
+  }
+  return { ok: true }
+}

--- a/bookbridge-next/lib/project-auth.ts
+++ b/bookbridge-next/lib/project-auth.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from 'next/server'
 import prisma from '@/lib/prisma'
 
-type GuardResult =
+export type GuardResult =
   | { ok: true }
   | { ok: false; response: NextResponse }
 


### PR DESCRIPTION
## Summary
Closes #29

- Add `PATCH` and `DELETE` handlers to `bookbridge-next/app/api/projects/[id]/route.ts`; `GET` already existed and already matched the error matrix.
- Zod `.strict()` validates the PATCH body (`name`, `targetLanguage`, `isPublic`); unknown keys or wrong-typed values → 400. API field names are mapped to Prisma columns (`name → title`, `targetLanguage → targetLang`).
- Extract `requireProjectOwner(projectId, userId)` guard into `bookbridge-next/lib/project-auth.ts` (refactor phase). Shared by PATCH and DELETE; ready for reuse by `projects/[id]/glossary/route.ts` in a follow-up.
- DELETE relies on Prisma schema's `onDelete: Cascade` on `Chapter` / `TranslationJob` / `GlossaryTerm` — no manual cascade logic needed.

## Acceptance Criteria
- [x] `GET /api/projects/[id]` returns project detail for the owning user; 403 for non-owner; 404 if not found
- [x] `PATCH /api/projects/[id]` updates `name` / `targetLanguage`; validates body with Zod; returns the updated project
    - *Note on `style`:* the API Contract in the issue lists `style`, but there is no `style` column on the Prisma `Project` model. Including it in Zod without a backing column would silently no-op the update. Omitted here; needs a follow-up issue that adds the column and the Zod field in a single change.
- [x] `PATCH /api/projects/[id]` with `{ isPublic: boolean }` toggles publish status
- [x] `DELETE /api/projects/[id]` removes project and cascades associated rows; ownership verified first
- [x] All mutation routes return 403 when `project.ownerId !== userId`
- [x] All request bodies validated with Zod before any Prisma call (ordering: `auth` → `findUnique` → ownership → `safeParse` → `update`)

### Security Definition of Done
- [x] `auth()` on every handler; 401 if unauthenticated
- [x] Resource-by-ID ownership check (403 on mismatch) via `requireProjectOwner`
- [x] All request bodies validated with Zod (`.strict()`)
- [x] No user-controlled values passed to shell or dynamic eval
- [x] No secrets in code; no stack traces or DB errors leaked to clients (generic 400 / 'Not found' / 'Forbidden')
- [x] API responses return only DB fields; no PII or tokens in logs
- [x] `npm audit` — no new dependencies added in this PR

## TDD Evidence
| Phase | Commit | Summary |
|---|---|---|
| Red | `5307559` | `test(red):` 15 failing tests in `bookbridge-next/__tests__/api/projects-id.test.ts` — required 3 (`test_patch_project_checks_ownership`, `test_delete_project_checks_ownership`, `test_patch_validates_body_with_zod`) plus full error-matrix coverage |
| Green | `9e397fb` | `feat(next):` PATCH + DELETE handlers — all 15 tests pass |
| Refactor | `cb5fc20` | `refactor:` extract `requireProjectOwner` — tests stay green |

Final: **67 / 67** tests pass across 12 files · `tsc --noEmit` clean · `eslint` clean (pre-existing unrelated warning in `projects.test.ts`).

## C.L.E.A.R. Self-Review
- [x] **Correct** — all 15 AC-linked tests pass; handler ordering puts `auth` and ownership ahead of body parsing so unauthenticated/unauthorized requests never touch user input
- [x] **Legible** — no magic numbers; handler bodies follow a uniform `auth → guard → parse → mutate → respond` shape; guard returns a discriminated union so caller intent is explicit
- [x] **Efficient** — guard uses `select: { id: true, ownerId: true }` (no heavy `include`); DELETE relies on DB-level cascade rather than N Prisma calls
- [x] **Abstracted** — duplicated ownership check extracted into `requireProjectOwner`; GET intentionally left inline because it already fetches the full project with includes
- [x] **Risk-aware** — OWASP A01 (ownership check + 403), A03 (Zod strict before Prisma), A05 (no raw SQL, no stack-trace leakage), A09 (generic error messages); no new deps, no secrets in code

## Out of Scope (Follow-ups)
- Add `style` column to `Project` + Zod field (atomic migration + schema update)
- Apply `requireProjectOwner` to `app/api/projects/[id]/glossary/route.ts` (same duplicated pattern across its GET + POST)
- Consider a sibling `requireJobOwner` for `app/api/jobs/[jobId]/route.ts`, which checks `job.project.ownerId` — different shape, deserves its own helper

## AI Disclosure
- AI-generated: ~95% (tests authored by `test-writer` sub-agent; implementation + refactor authored by Claude; human pair verified flow and approved each phase)
- Tool used: Claude Code — Opus 4.7 (1M context), model id `claude-opus-4-7[1m]`
- Human review: yes — all three commits reviewed for logic, error-matrix ordering, and schema/API-field mapping before push