### PR TITLE
S4-2: Publish project → public link (publish/unpublish toggle + publicToken)

### DIFF
--- a/bookbridge-next/__tests__/api/projects-id.test.ts
+++ b/bookbridge-next/__tests__/api/projects-id.test.ts
@@ -279,6 +279,151 @@ describe('PATCH /api/projects/[id]', () => {
     const body = await res.json()
     expect(body.data.isPublic).toBe(true)
   })
+
+  // ---------------------------------------------------------------------------
+  // Issue #24 — Publish/unpublish toggle + publicToken (red phase tests)
+  // ---------------------------------------------------------------------------
+
+  // test_publish_generates_public_token
+  // The PATCH handler must generate a UUID v4 publicToken when isPublic: true.
+  // Currently the handler passes isPublic straight to Prisma without setting publicToken,
+  // so the response will NOT contain a UUID v4 publicToken — this test will FAIL.
+  it('test_publish_generates_public_token: returns 200 with UUID v4 publicToken when owner publishes project', async () => {
+    vi.mocked(auth).mockResolvedValueOnce({ userId: OWNER_ID } as AuthReturn)
+    mockProjectFindUnique.mockResolvedValueOnce(fakeProjectSlim)
+    // The mock simulates what the DB row would look like AFTER the handler
+    // sets publicToken. Because the handler currently does NOT set it, the
+    // actual Prisma update call will not include publicToken, and the real
+    // implementation is missing — the test must fail.
+    const generatedToken = 'aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee'
+    const updatedProject = {
+      ...fakeProject,
+      isPublic: true,
+      publicToken: generatedToken,
+    }
+    mockProjectUpdate.mockResolvedValueOnce(updatedProject)
+    const { PATCH } = await import('@/app/api/projects/[id]/route')
+    const res = await PATCH(
+      makePatchRequest(PROJECT_ID, { isPublic: true }),
+      makeParams(PROJECT_ID),
+    )
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.data.isPublic).toBe(true)
+    // The handler must pass publicToken to prisma.update so the returned row
+    // contains it. More importantly it must pass a freshly generated UUID v4.
+    const UUID_V4 = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
+    expect(body.data.publicToken).toBeDefined()
+    expect(body.data.publicToken).toMatch(UUID_V4)
+    // Verify the handler actually sent publicToken to Prisma (not just echoed
+    // the mock value). The update call's data argument must include publicToken.
+    expect(mockProjectUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          publicToken: expect.stringMatching(UUID_V4),
+        }),
+      }),
+    )
+  })
+
+  // test_unpublish_clears_token
+  // The PATCH handler must set publicToken to null when isPublic: false.
+  // Currently the handler does NOT touch publicToken at all — this test will FAIL.
+  it('test_unpublish_clears_token: returns 200 with publicToken null when owner unpublishes project', async () => {
+    vi.mocked(auth).mockResolvedValueOnce({ userId: OWNER_ID } as AuthReturn)
+    mockProjectFindUnique.mockResolvedValueOnce(fakeProjectSlim)
+    const updatedProject = {
+      ...fakeProject,
+      isPublic: false,
+      publicToken: null,
+    }
+    mockProjectUpdate.mockResolvedValueOnce(updatedProject)
+    const { PATCH } = await import('@/app/api/projects/[id]/route')
+    const res = await PATCH(
+      makePatchRequest(PROJECT_ID, { isPublic: false }),
+      makeParams(PROJECT_ID),
+    )
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.data.isPublic).toBe(false)
+    expect(body.data.publicToken).toBeNull()
+    // The handler must explicitly pass publicToken: null to Prisma so the DB
+    // column is cleared (not just left as-is).
+    expect(mockProjectUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          publicToken: null,
+        }),
+      }),
+    )
+  })
+
+  // test_publish_checks_ownership
+  // Non-owner must receive 403 AND the response body must expose a
+  // `publicUrl` field as null (not a generated token), confirming the
+  // handler's publish-specific response envelope is also guarded.
+  // The existing handler returns a generic { error: 'Forbidden' } with no
+  // publicUrl field at all — so `body.publicUrl === null` will fail until
+  // the publish handler explicitly shapes its 403 response to include
+  // `{ error: 'Forbidden', publicUrl: null }`.
+  it('test_publish_checks_ownership: returns 403 with no publicUrl when non-owner tries to publish project', async () => {
+    vi.mocked(auth).mockResolvedValueOnce({ userId: OTHER_USER_ID } as AuthReturn)
+    mockProjectFindUnique.mockResolvedValueOnce(fakeProjectSlim) // ownerId = OWNER_ID
+    const { PATCH } = await import('@/app/api/projects/[id]/route')
+    const res = await PATCH(
+      makePatchRequest(PROJECT_ID, { isPublic: true }),
+      makeParams(PROJECT_ID),
+    )
+    expect(res.status).toBe(403)
+    // publicToken must never be generated for a non-owner request
+    expect(mockProjectUpdate).not.toHaveBeenCalled()
+    // The 403 body must explicitly carry publicUrl: null so callers know
+    // no link was generated. This field is absent in the current implementation.
+    const body = await res.json()
+    expect(body.publicUrl).toBeNull()
+  })
+
+  // test_republish_rotates_token
+  // Re-publishing an already-published project must produce a NEW publicToken,
+  // invalidating any previously shared links. The handler must call
+  // crypto.randomUUID() unconditionally when isPublic: true, regardless of the
+  // project's current isPublic state. This test verifies the update payload
+  // contains a UUID v4 (i.e. a freshly generated token, not the old one).
+  // Because the current handler does not generate publicToken at all,
+  // this test will FAIL.
+  it('test_republish_rotates_token: returns 200 with a new UUID v4 publicToken when owner republishes an already-public project', async () => {
+    const OLD_TOKEN = 'ffffffff-0000-4000-8000-111111111111'
+    vi.mocked(auth).mockResolvedValueOnce({ userId: OWNER_ID } as AuthReturn)
+    mockProjectFindUnique.mockResolvedValueOnce(fakeProjectSlim)
+    // The DB row already had a token; after republish it has a new one.
+    const NEW_TOKEN = 'cccccccc-1111-4222-9333-444444444444'
+    const updatedProject = {
+      ...fakeProject,
+      isPublic: true,
+      publicToken: NEW_TOKEN,
+    }
+    mockProjectUpdate.mockResolvedValueOnce(updatedProject)
+    const { PATCH } = await import('@/app/api/projects/[id]/route')
+    const res = await PATCH(
+      makePatchRequest(PROJECT_ID, { isPublic: true }),
+      makeParams(PROJECT_ID),
+    )
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    const UUID_V4 = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
+    expect(body.data.publicToken).toMatch(UUID_V4)
+    // The token passed to Prisma must be a fresh UUID v4, not the old token.
+    expect(mockProjectUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          publicToken: expect.stringMatching(UUID_V4),
+        }),
+      }),
+    )
+    // The token in the Prisma call must differ from the old token.
+    const updateCall = mockProjectUpdate.mock.calls[0][0] as { data: { publicToken: string } }
+    expect(updateCall.data.publicToken).not.toBe(OLD_TOKEN)
+  })
 })
 
 // ---------------------------------------------------------------------------

--- a/bookbridge-next/__tests__/api/projects-id.test.ts
+++ b/bookbridge-next/__tests__/api/projects-id.test.ts
@@ -380,22 +380,22 @@ describe('PATCH /api/projects/[id]', () => {
     // The 403 body must explicitly carry publicUrl: null so callers know
     // no link was generated. This field is absent in the current implementation.
     const body = await res.json()
+    expect(body.error).toBe('Forbidden')
     expect(body.publicUrl).toBeNull()
   })
 
-  // test_republish_rotates_token
-  // Re-publishing an already-published project must produce a NEW publicToken,
-  // invalidating any previously shared links. The handler must call
-  // crypto.randomUUID() unconditionally when isPublic: true, regardless of the
-  // project's current isPublic state. This test verifies the update payload
-  // contains a UUID v4 (i.e. a freshly generated token, not the old one).
-  // Because the current handler does not generate publicToken at all,
-  // this test will FAIL.
-  it('test_republish_rotates_token: returns 200 with a new UUID v4 publicToken when owner republishes an already-public project', async () => {
-    const OLD_TOKEN = 'ffffffff-0000-4000-8000-111111111111'
+  // test_publish_always_generates_fresh_uuid
+  // Re-publishing an already-public project must produce a newly-generated
+  // publicToken rather than reuse whatever the row currently holds. The
+  // handler's rotation strategy is to call crypto.randomUUID() unconditionally
+  // on every publish — so the invariant we can actually verify is "the token
+  // passed to Prisma is a fresh UUID v4 independent of the current DB value".
+  // (We cannot assert token!==oldToken here because the ownership guard's
+  // findUnique uses `select: { id, ownerId }`, so the handler never reads the
+  // existing publicToken — rotation is by construction, not by comparison.)
+  it('test_publish_always_generates_fresh_uuid: owner republishing an already-public project sends a fresh UUID v4 to Prisma', async () => {
     vi.mocked(auth).mockResolvedValueOnce({ userId: OWNER_ID } as AuthReturn)
     mockProjectFindUnique.mockResolvedValueOnce(fakeProjectSlim)
-    // The DB row already had a token; after republish it has a new one.
     const NEW_TOKEN = 'cccccccc-1111-4222-9333-444444444444'
     const updatedProject = {
       ...fakeProject,
@@ -409,10 +409,8 @@ describe('PATCH /api/projects/[id]', () => {
       makeParams(PROJECT_ID),
     )
     expect(res.status).toBe(200)
-    const body = await res.json()
     const UUID_V4 = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
-    expect(body.data.publicToken).toMatch(UUID_V4)
-    // The token passed to Prisma must be a fresh UUID v4, not the old token.
+    // The token passed to Prisma must be a UUID v4 (crypto.randomUUID output).
     expect(mockProjectUpdate).toHaveBeenCalledWith(
       expect.objectContaining({
         data: expect.objectContaining({
@@ -420,9 +418,6 @@ describe('PATCH /api/projects/[id]', () => {
         }),
       }),
     )
-    // The token in the Prisma call must differ from the old token.
-    const updateCall = mockProjectUpdate.mock.calls[0][0] as { data: { publicToken: string } }
-    expect(updateCall.data.publicToken).not.toBe(OLD_TOKEN)
   })
 })
 

--- a/bookbridge-next/app/api/projects/[id]/route.ts
+++ b/bookbridge-next/app/api/projects/[id]/route.ts
@@ -56,14 +56,25 @@ export async function PATCH(
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
   }
 
-  const guard = await requireProjectOwner(id, userId)
-  if (!guard.ok) return guard.response
-
   let raw: unknown
   try {
     raw = await req.json()
   } catch {
     return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 })
+  }
+
+  const isPublishAttempt =
+    raw !== null && typeof raw === 'object' && 'isPublic' in raw
+
+  const guard = await requireProjectOwner(id, userId)
+  if (!guard.ok) {
+    if (isPublishAttempt && guard.response.status === 403) {
+      return NextResponse.json(
+        { error: 'Forbidden', publicUrl: null },
+        { status: 403 },
+      )
+    }
+    return guard.response
   }
 
   const parsed = patchSchema.safeParse(raw)
@@ -77,10 +88,22 @@ export async function PATCH(
     )
   }
 
-  const data: { title?: string; targetLang?: string; isPublic?: boolean } = {}
+  const data: {
+    title?: string
+    targetLang?: string
+    isPublic?: boolean
+    publicToken?: string | null
+  } = {}
   if (parsed.data.name !== undefined) data.title = parsed.data.name
   if (parsed.data.targetLanguage !== undefined) data.targetLang = parsed.data.targetLanguage
-  if (parsed.data.isPublic !== undefined) data.isPublic = parsed.data.isPublic
+  if (parsed.data.isPublic === true) {
+    // Always rotate the token on publish so previously-shared links are invalidated.
+    data.isPublic = true
+    data.publicToken = crypto.randomUUID()
+  } else if (parsed.data.isPublic === false) {
+    data.isPublic = false
+    data.publicToken = null
+  }
 
   if (Object.keys(data).length === 0) {
     return NextResponse.json(

--- a/bookbridge-next/app/api/projects/[id]/route.ts
+++ b/bookbridge-next/app/api/projects/[id]/route.ts
@@ -88,21 +88,13 @@ export async function PATCH(
     )
   }
 
-  const data: {
-    title?: string
-    targetLang?: string
-    isPublic?: boolean
-    publicToken?: string | null
-  } = {}
+  const data: Prisma.ProjectUpdateInput = {}
   if (parsed.data.name !== undefined) data.title = parsed.data.name
   if (parsed.data.targetLanguage !== undefined) data.targetLang = parsed.data.targetLanguage
-  if (parsed.data.isPublic === true) {
-    // Always rotate the token on publish so previously-shared links are invalidated.
-    data.isPublic = true
-    data.publicToken = crypto.randomUUID()
-  } else if (parsed.data.isPublic === false) {
-    data.isPublic = false
-    data.publicToken = null
+  if (parsed.data.isPublic !== undefined) {
+    // Rotate the token on every publish so previously-shared links are invalidated.
+    data.isPublic = parsed.data.isPublic
+    data.publicToken = parsed.data.isPublic ? crypto.randomUUID() : null
   }
 
   if (Object.keys(data).length === 0) {

--- a/bookbridge-next/app/api/projects/[id]/route.ts
+++ b/bookbridge-next/app/api/projects/[id]/route.ts
@@ -68,7 +68,7 @@ export async function PATCH(
 
   const guard = await requireProjectOwner(id, userId)
   if (!guard.ok) {
-    if (isPublishAttempt && guard.response.status === 403) {
+    if (isPublishAttempt && guard.reason === 'forbidden') {
       return NextResponse.json(
         { error: 'Forbidden', publicUrl: null },
         { status: 403 },

--- a/bookbridge-next/lib/project-auth.ts
+++ b/bookbridge-next/lib/project-auth.ts
@@ -1,9 +1,11 @@
 import { NextResponse } from 'next/server'
 import prisma from '@/lib/prisma'
 
+export type GuardFailure = 'not_found' | 'forbidden'
+
 export type GuardResult =
   | { ok: true }
-  | { ok: false; response: NextResponse }
+  | { ok: false; reason: GuardFailure; response: NextResponse }
 
 export async function requireProjectOwner(
   projectId: string,
@@ -14,10 +16,18 @@ export async function requireProjectOwner(
     select: { id: true, ownerId: true },
   })
   if (!project) {
-    return { ok: false, response: NextResponse.json({ error: 'Not found' }, { status: 404 }) }
+    return {
+      ok: false,
+      reason: 'not_found',
+      response: NextResponse.json({ error: 'Not found' }, { status: 404 }),
+    }
   }
   if (project.ownerId !== userId) {
-    return { ok: false, response: NextResponse.json({ error: 'Forbidden' }, { status: 403 }) }
+    return {
+      ok: false,
+      reason: 'forbidden',
+      response: NextResponse.json({ error: 'Forbidden' }, { status: 403 }),
+    }
   }
   return { ok: true }
 }

--- a/bookbridge-next/prisma/migrations/20260419010450_add_public_token/migration.sql
+++ b/bookbridge-next/prisma/migrations/20260419010450_add_public_token/migration.sql
@@ -1,0 +1,5 @@
+-- AlterTable
+ALTER TABLE "Project" ADD COLUMN "publicToken" TEXT;
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Project_publicToken_key" ON "Project"("publicToken");

--- a/bookbridge-next/prisma/schema.prisma
+++ b/bookbridge-next/prisma/schema.prisma
@@ -32,6 +32,7 @@ model Project {
   targetLang  String           @default("zh-Hans")
   status      ProjectStatus    @default(DRAFT)
   isPublic    Boolean          @default(false)
+  publicToken String?          @unique
   ownerId     String
   owner       User             @relation(fields: [ownerId], references: [clerkId])
   chapters    Chapter[]


### PR DESCRIPTION
## Summary
Closes #24

- `PATCH /api/projects/[id]` now accepts `{ isPublic: boolean }`: toggling to `true` generates a fresh UUID v4 `publicToken` (always rotated — republishing invalidates previously shared links); toggling to `false` clears it to `null`.
- Non-owner publish attempts return `403 { error: 'Forbidden', publicUrl: null }` so the client knows no link was generated; all other PATCH 403s keep the generic shape.
- Adds nullable `publicToken String? @unique` to the `Project` model + migration `20260419010450_add_public_token`; token generation uses Node's built-in `crypto.randomUUID()` (no new dependency) and is never written to any log.

## Acceptance Criteria
- [x] `PATCH /api/projects/[id]` with `{isPublic: true}` generates a UUID v4 `publicToken` and stores it in the Project row
- [x] `PATCH /api/projects/[id]` with `{isPublic: false}` clears `publicToken` (sets to null)
- [x] Only the project owner can publish/unpublish (403 for non-owner)
- [x] The public link is in the form `/read/[publicToken]` (token shape/route reserved; consuming route lands in a later issue)
- [x] `publicToken` is never written to application logs
- [x] Re-publishing an already-published project generates a new token (invalidating old links)

## C.L.E.A.R. Self-Review
- [x] **Correct** — 22 tests on this route file pass (incl. 4 red-phase publish tests); full suite 83/83 green; tsc clean
- [x] **Legible** — single-branch toggle expresses publish/unpublish semantics; `Prisma.ProjectUpdateInput` as source of truth for the update shape
- [x] **Efficient** — one Prisma read (ownership guard) + one Prisma write per request; no extra DB round-trips for the token
- [x] **Abstracted** — publish-specific 403 shape inlined (used once); update-data type borrowed from Prisma; ownership guard already extracted in `lib/project-auth.ts`
- [x] **Risk-aware** — A01 ownership check, A03 Zod-validated boolean, A09 no token in logs; token uses Node's `crypto.randomUUID()`

## AI Disclosure
- AI-generated: ~80%
- Tool used: Claude Code (claude-opus-4-7)
- Human review: yes — TDD red→green→refactor chain, logic verified, tests checked manually