### PR TITLE
S4-4: BFF API — Public reading routes

### DIFF
--- a/bookbridge-next/app/api/read/[token]/__tests__/route.test.ts
+++ b/bookbridge-next/app/api/read/[token]/__tests__/route.test.ts
@@ -36,7 +36,9 @@ vi.mock('@/lib/prisma', () => ({
 // Test constants
 // ---------------------------------------------------------------------------
 const VALID_TOKEN = 'aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee'
-const INVALID_TOKEN = 'zzzzzzzz-0000-4000-a000-000000000000'
+// Valid UUID format but unknown to the DB — tests "no such published project"
+// while still passing the route's UUID format validation.
+const INVALID_TOKEN = 'deadbeef-dead-4bee-8ead-deadbeefcafe'
 const PROJECT_ID = 'clh3p7b1p0001qzrmkf8g4m0i'
 const OWNER_ID = 'user_owner_abc'
 
@@ -161,6 +163,16 @@ describe('GET /api/read/[token]', () => {
     const res = await GET(makeGetRequest(''), makeParams(''))
     expect(res.status).toBe(400)
     // Prisma must never be called for an invalid token
+    expect(mockProjectFindFirst).not.toHaveBeenCalled()
+  })
+
+  // Input validation — tokens that are not UUID format must be rejected with 400
+  // before reaching Prisma (whitespace, garbage strings, newline-injection, etc).
+  it('returns 400 when token path param is a non-UUID string', async () => {
+    const { GET } = await import('@/app/api/read/[token]/route')
+    const garbage = '   '
+    const res = await GET(makeGetRequest(garbage), makeParams(garbage))
+    expect(res.status).toBe(400)
     expect(mockProjectFindFirst).not.toHaveBeenCalled()
   })
 

--- a/bookbridge-next/app/api/read/[token]/__tests__/route.test.ts
+++ b/bookbridge-next/app/api/read/[token]/__tests__/route.test.ts
@@ -1,0 +1,185 @@
+/**
+ * Failing (red) tests for issue #32 — GET /api/read/[token]
+ *
+ * This route is intentionally unauthenticated — the publicToken IS the
+ * authorization. No Clerk auth() call is expected or mocked.
+ *
+ * Required test cases:
+ *   - test_valid_token_returns_metadata   — published project + valid token → 200
+ *   - test_invalid_token_returns_404      — unknown token → 404
+ *   - test_unpublished_project_returns_404 — token matches but isPublic=false → 404
+ *
+ * Security assertions:
+ *   - 200 response must not include ownerId or other internal fields
+ *   - 404 response body must be identical for unknown vs unpublished token
+ *     (prevents enumeration — OWASP A01)
+ *
+ * All tests fail with "Cannot find module" because the route does not exist.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { NextRequest } from 'next/server'
+
+// No Clerk mock — these routes intentionally skip auth()
+
+const mockProjectFindFirst = vi.fn()
+
+vi.mock('@/lib/prisma', () => ({
+  default: {
+    project: {
+      findFirst: (...args: unknown[]) => mockProjectFindFirst(...args),
+    },
+  },
+}))
+
+// ---------------------------------------------------------------------------
+// Test constants
+// ---------------------------------------------------------------------------
+const VALID_TOKEN = 'aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee'
+const INVALID_TOKEN = 'zzzzzzzz-0000-4000-a000-000000000000'
+const PROJECT_ID = 'clh3p7b1p0001qzrmkf8g4m0i'
+const OWNER_ID = 'user_owner_abc'
+
+const publishedProject = {
+  id: PROJECT_ID,
+  title: 'My Translated Novel',
+  sourceLang: 'en',
+  targetLang: 'zh-Hans',
+  status: 'COMPLETED',
+  isPublic: true,
+  publicToken: VALID_TOKEN,
+  ownerId: OWNER_ID,
+  createdAt: new Date(),
+  updatedAt: new Date(),
+  chapters: [
+    { id: 'ch1', number: 1, title: 'Chapter One' },
+    { id: 'ch2', number: 2, title: 'Chapter Two' },
+  ],
+}
+
+const unpublishedProject = {
+  ...publishedProject,
+  isPublic: false,
+  publicToken: VALID_TOKEN,
+}
+
+// ---------------------------------------------------------------------------
+// Request factory helpers
+// ---------------------------------------------------------------------------
+function makeGetRequest(token: string): NextRequest {
+  return new NextRequest(`http://localhost:3000/api/read/${token}`, {
+    method: 'GET',
+  })
+}
+
+function makeParams(token: string) {
+  return { params: Promise.resolve({ token }) }
+}
+
+// ---------------------------------------------------------------------------
+// Test suite
+// ---------------------------------------------------------------------------
+describe('GET /api/read/[token]', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.resetModules()
+  })
+
+  // Happy path — test_valid_token_returns_metadata
+  // Published project with matching publicToken → 200 with name + targetLanguage.
+  // Response must NOT include ownerId (data exposure — OWASP A09).
+  it('test_valid_token_returns_metadata: returns 200 with project metadata for a published project', async () => {
+    mockProjectFindFirst.mockResolvedValueOnce(publishedProject)
+    const { GET } = await import('@/app/api/read/[token]/route')
+    const res = await GET(makeGetRequest(VALID_TOKEN), makeParams(VALID_TOKEN))
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    // Must include the fields the reading view needs
+    expect(body.data).toBeDefined()
+    expect(body.data.title).toBe('My Translated Novel')
+    expect(body.data.targetLanguage).toBeDefined()
+    // Must NOT expose internal ownership data (OWASP A09 — minimal data exposure)
+    expect(body.data.ownerId).toBeUndefined()
+    // Must NOT expose publicToken in the response (it's the auth credential)
+    expect(body.data.publicToken).toBeUndefined()
+  })
+
+  // Edge case — test_invalid_token_returns_404
+  // Unknown token (no row in DB) must return 404 with a plain message.
+  // Must NOT disclose whether the project exists (prevents enumeration — OWASP A01).
+  it('test_invalid_token_returns_404: returns 404 for an unknown token', async () => {
+    mockProjectFindFirst.mockResolvedValueOnce(null)
+    const { GET } = await import('@/app/api/read/[token]/route')
+    const res = await GET(makeGetRequest(INVALID_TOKEN), makeParams(INVALID_TOKEN))
+    expect(res.status).toBe(404)
+    const body = await res.json()
+    expect(body.error).toBeDefined()
+    // Must not leak existence information
+    expect(body.error).not.toMatch(/exist|found|public/i)
+  })
+
+  // Edge case — test_unpublished_project_returns_404
+  // Token matches a project but isPublic=false → must return 404, NOT 401 or 403.
+  // Returning 403 would confirm the project exists; 404 prevents enumeration.
+  // The 404 body shape must be identical to the unknown-token case (OWASP A01).
+  it('test_unpublished_project_returns_404: returns 404 when project exists but isPublic is false', async () => {
+    // Simulate the route finding the project by token but isPublic=false.
+    // The implementation should query WHERE publicToken=token AND isPublic=true,
+    // so findFirst returns null for unpublished projects. We return null here
+    // to model the correct implementation contract.
+    mockProjectFindFirst.mockResolvedValueOnce(null)
+    const { GET } = await import('@/app/api/read/[token]/route')
+    const res = await GET(makeGetRequest(VALID_TOKEN), makeParams(VALID_TOKEN))
+    // Must be 404, NOT 401 or 403 — prevents enumeration of whether project exists
+    expect(res.status).toBe(404)
+    // Must not be 401 (no auth required for this route)
+    expect(res.status).not.toBe(401)
+    expect(res.status).not.toBe(403)
+  })
+
+  // Security — unpublished and unknown-token responses must be indistinguishable
+  // (same status + same body shape prevents existence enumeration — OWASP A01)
+  it('returns identical 404 body shape for unknown token and unpublished-token cases', async () => {
+    // Unknown token case
+    mockProjectFindFirst.mockResolvedValueOnce(null)
+    const { GET: GET1 } = await import('@/app/api/read/[token]/route')
+    const unknownRes = await GET1(makeGetRequest(INVALID_TOKEN), makeParams(INVALID_TOKEN))
+    const unknownBody = await unknownRes.json()
+
+    vi.resetModules()
+
+    // Unpublished token case — findFirst returns null (correct query filters isPublic=true)
+    mockProjectFindFirst.mockResolvedValueOnce(null)
+    const { GET: GET2 } = await import('@/app/api/read/[token]/route')
+    const unpublishedRes = await GET2(makeGetRequest(VALID_TOKEN), makeParams(VALID_TOKEN))
+    const unpublishedBody = await unpublishedRes.json()
+
+    expect(unknownRes.status).toBe(404)
+    expect(unpublishedRes.status).toBe(404)
+    // Body shapes must be identical — same keys present
+    expect(Object.keys(unknownBody).sort()).toEqual(Object.keys(unpublishedBody).sort())
+  })
+
+  // Input validation — empty / whitespace-only token must be rejected with 400
+  // (OWASP A03 — validate all inputs with Zod before Prisma query)
+  it('returns 400 when token path param is an empty string', async () => {
+    const { GET } = await import('@/app/api/read/[token]/route')
+    const res = await GET(makeGetRequest(''), makeParams(''))
+    expect(res.status).toBe(400)
+    // Prisma must never be called for an invalid token
+    expect(mockProjectFindFirst).not.toHaveBeenCalled()
+  })
+
+  // Edge case — route must not call auth() at all (no Clerk dependency)
+  // A published project accessible without any auth header
+  it('returns 200 without any Authorization header (public route — no auth required)', async () => {
+    mockProjectFindFirst.mockResolvedValueOnce(publishedProject)
+    const { GET } = await import('@/app/api/read/[token]/route')
+    // Request has no Authorization header
+    const req = new NextRequest(`http://localhost:3000/api/read/${VALID_TOKEN}`, {
+      method: 'GET',
+    })
+    const res = await GET(req, makeParams(VALID_TOKEN))
+    expect(res.status).toBe(200)
+  })
+})

--- a/bookbridge-next/app/api/read/[token]/__tests__/route.test.ts
+++ b/bookbridge-next/app/api/read/[token]/__tests__/route.test.ts
@@ -57,12 +57,6 @@ const publishedProject = {
   ],
 }
 
-const unpublishedProject = {
-  ...publishedProject,
-  isPublic: false,
-  publicToken: VALID_TOKEN,
-}
-
 // ---------------------------------------------------------------------------
 // Request factory helpers
 // ---------------------------------------------------------------------------

--- a/bookbridge-next/app/api/read/[token]/chunks/[chunkId]/__tests__/route.test.ts
+++ b/bookbridge-next/app/api/read/[token]/chunks/[chunkId]/__tests__/route.test.ts
@@ -1,0 +1,217 @@
+/**
+ * Failing (red) tests for issue #32 — GET /api/read/[token]/chunks/[chunkId]
+ *
+ * This route is intentionally unauthenticated — the publicToken IS the
+ * authorization. The chunkId scopes the response to a single chapter's content.
+ *
+ * Required test cases:
+ *   - Valid token + valid chunk belonging to that project → 200 with originalText + translatedText
+ *   - Invalid/unpublished token → 404
+ *   - Chunk that does not belong to that token's project → 404 (prevent cross-project access)
+ *   - Unknown chunkId → 404
+ *
+ * Security assertions:
+ *   - Cross-project chunk access must be blocked (OWASP A01 — prevent IDOR)
+ *   - 404 body shape must not disclose whether project or chunk exists
+ *
+ * All tests fail with "Cannot find module" because the route does not exist.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { NextRequest } from 'next/server'
+
+// No Clerk mock — these routes intentionally skip auth()
+
+const mockProjectFindFirst = vi.fn()
+const mockChapterFindUnique = vi.fn()
+
+vi.mock('@/lib/prisma', () => ({
+  default: {
+    project: {
+      findFirst: (...args: unknown[]) => mockProjectFindFirst(...args),
+    },
+    chapter: {
+      findUnique: (...args: unknown[]) => mockChapterFindUnique(...args),
+    },
+  },
+}))
+
+// ---------------------------------------------------------------------------
+// Test constants
+// ---------------------------------------------------------------------------
+const VALID_TOKEN = 'aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee'
+const INVALID_TOKEN = 'zzzzzzzz-0000-4000-a000-000000000000'
+const PROJECT_ID = 'clh3p7b1p0001qzrmkf8g4m0i'
+const OTHER_PROJECT_ID = 'clh3p7b1p0001qzrmkf8g4m0j'
+const CHUNK_ID = 'clh4c1a2b0002qzrmkf8g4n1j'
+const UNKNOWN_CHUNK_ID = 'clhXXXXXXXXXXXXXXXXXXXXXX'
+
+const publishedProject = {
+  id: PROJECT_ID,
+  title: 'My Translated Novel',
+  sourceLang: 'en',
+  targetLang: 'zh-Hans',
+  status: 'COMPLETED',
+  isPublic: true,
+  publicToken: VALID_TOKEN,
+}
+
+const fakeChapter = {
+  id: CHUNK_ID,
+  projectId: PROJECT_ID,
+  number: 1,
+  title: 'Chapter One',
+  startPage: 1,
+  endPage: 20,
+  pageCount: 20,
+  sourceContent: 'It was the best of times, it was the worst of times.',
+  translation: '这是最好的时代，这是最坏的时代。',
+}
+
+// A chapter that belongs to a DIFFERENT project (cross-project IDOR scenario)
+const chapterFromOtherProject = {
+  ...fakeChapter,
+  id: CHUNK_ID,
+  projectId: OTHER_PROJECT_ID,
+}
+
+// ---------------------------------------------------------------------------
+// Request factory helpers
+// ---------------------------------------------------------------------------
+function makeGetRequest(token: string, chunkId: string): NextRequest {
+  return new NextRequest(
+    `http://localhost:3000/api/read/${token}/chunks/${chunkId}`,
+    { method: 'GET' },
+  )
+}
+
+function makeParams(token: string, chunkId: string) {
+  return { params: Promise.resolve({ token, chunkId }) }
+}
+
+// ---------------------------------------------------------------------------
+// Test suite
+// ---------------------------------------------------------------------------
+describe('GET /api/read/[token]/chunks/[chunkId]', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.resetModules()
+  })
+
+  // Happy path — valid published token + chunk belonging to that project → 200
+  // Response must include originalText + translatedText (reading view fields).
+  it('returns 200 with originalText and translatedText for a valid token and chunk', async () => {
+    mockProjectFindFirst.mockResolvedValueOnce(publishedProject)
+    mockChapterFindUnique.mockResolvedValueOnce(fakeChapter)
+    const { GET } = await import('@/app/api/read/[token]/chunks/[chunkId]/route')
+    const res = await GET(
+      makeGetRequest(VALID_TOKEN, CHUNK_ID),
+      makeParams(VALID_TOKEN, CHUNK_ID),
+    )
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.data).toBeDefined()
+    // Response must expose reading-view field names (not raw DB column names)
+    expect(body.data.originalText).toBe(fakeChapter.sourceContent)
+    expect(body.data.translatedText).toBe(fakeChapter.translation)
+    // Must NOT expose internal fields
+    expect(body.data.projectId).toBeUndefined()
+  })
+
+  // Edge case — invalid/unknown token → 404 (no project found)
+  // Must not reveal whether the project exists (OWASP A01 enumeration prevention).
+  it('returns 404 when the token is unknown (no published project found)', async () => {
+    mockProjectFindFirst.mockResolvedValueOnce(null)
+    const { GET } = await import('@/app/api/read/[token]/chunks/[chunkId]/route')
+    const res = await GET(
+      makeGetRequest(INVALID_TOKEN, CHUNK_ID),
+      makeParams(INVALID_TOKEN, CHUNK_ID),
+    )
+    expect(res.status).toBe(404)
+    // Must not be 401 or 403 — token-as-auth pattern
+    expect(res.status).not.toBe(401)
+    expect(res.status).not.toBe(403)
+  })
+
+  // Edge case — unpublished project token → 404
+  // findFirst with isPublic=true filter returns null for unpublished projects.
+  it('returns 404 when the token matches a project that is not published', async () => {
+    // Route queries WHERE publicToken=token AND isPublic=true → returns null
+    mockProjectFindFirst.mockResolvedValueOnce(null)
+    const { GET } = await import('@/app/api/read/[token]/chunks/[chunkId]/route')
+    const res = await GET(
+      makeGetRequest(VALID_TOKEN, CHUNK_ID),
+      makeParams(VALID_TOKEN, CHUNK_ID),
+    )
+    expect(res.status).toBe(404)
+  })
+
+  // Security — cross-project chunk access must be blocked (OWASP A01 — IDOR)
+  // Attacker uses a valid token for project A but supplies a chunkId from project B.
+  // The route must verify chunk.projectId === project.id before returning data.
+  it('returns 404 when the chunk belongs to a different project (cross-project IDOR attempt)', async () => {
+    mockProjectFindFirst.mockResolvedValueOnce(publishedProject) // project A
+    mockChapterFindUnique.mockResolvedValueOnce(chapterFromOtherProject) // chunk from project B
+    const { GET } = await import('@/app/api/read/[token]/chunks/[chunkId]/route')
+    const res = await GET(
+      makeGetRequest(VALID_TOKEN, CHUNK_ID),
+      makeParams(VALID_TOKEN, CHUNK_ID),
+    )
+    // Must be 404, not 200 — the chunk does not belong to the token's project
+    expect(res.status).toBe(404)
+  })
+
+  // Edge case — unknown chunkId (chapter not found in DB) → 404
+  // Even with a valid token, a non-existent chunkId must return 404.
+  it('returns 404 when the chunkId does not exist in the database', async () => {
+    mockProjectFindFirst.mockResolvedValueOnce(publishedProject)
+    mockChapterFindUnique.mockResolvedValueOnce(null)
+    const { GET } = await import('@/app/api/read/[token]/chunks/[chunkId]/route')
+    const res = await GET(
+      makeGetRequest(VALID_TOKEN, UNKNOWN_CHUNK_ID),
+      makeParams(VALID_TOKEN, UNKNOWN_CHUNK_ID),
+    )
+    expect(res.status).toBe(404)
+  })
+
+  // Input validation — empty token must be rejected with 400 before hitting Prisma
+  // (OWASP A03 — validate all inputs with Zod)
+  it('returns 400 when the token path param is an empty string', async () => {
+    const { GET } = await import('@/app/api/read/[token]/chunks/[chunkId]/route')
+    const res = await GET(
+      makeGetRequest('', CHUNK_ID),
+      makeParams('', CHUNK_ID),
+    )
+    expect(res.status).toBe(400)
+    expect(mockProjectFindFirst).not.toHaveBeenCalled()
+  })
+
+  // Input validation — empty chunkId must be rejected with 400 before hitting Prisma
+  // (OWASP A03 — validate all inputs with Zod)
+  it('returns 400 when the chunkId path param is an empty string', async () => {
+    const { GET } = await import('@/app/api/read/[token]/chunks/[chunkId]/route')
+    const res = await GET(
+      makeGetRequest(VALID_TOKEN, ''),
+      makeParams(VALID_TOKEN, ''),
+    )
+    expect(res.status).toBe(400)
+    expect(mockProjectFindFirst).not.toHaveBeenCalled()
+  })
+
+  // Edge case — chunk with null translatedText must still return 200 (translation in progress)
+  // originalText is always present; translatedText may be null for untranslated chapters.
+  it('returns 200 with translatedText as null when chapter has no translation yet', async () => {
+    const untranslatedChapter = { ...fakeChapter, translation: null }
+    mockProjectFindFirst.mockResolvedValueOnce(publishedProject)
+    mockChapterFindUnique.mockResolvedValueOnce(untranslatedChapter)
+    const { GET } = await import('@/app/api/read/[token]/chunks/[chunkId]/route')
+    const res = await GET(
+      makeGetRequest(VALID_TOKEN, CHUNK_ID),
+      makeParams(VALID_TOKEN, CHUNK_ID),
+    )
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.data.originalText).toBe(fakeChapter.sourceContent)
+    expect(body.data.translatedText).toBeNull()
+  })
+})

--- a/bookbridge-next/app/api/read/[token]/chunks/[chunkId]/__tests__/route.test.ts
+++ b/bookbridge-next/app/api/read/[token]/chunks/[chunkId]/__tests__/route.test.ts
@@ -40,7 +40,9 @@ vi.mock('@/lib/prisma', () => ({
 // Test constants
 // ---------------------------------------------------------------------------
 const VALID_TOKEN = 'aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee'
-const INVALID_TOKEN = 'zzzzzzzz-0000-4000-a000-000000000000'
+// Valid UUID format but unknown to the DB — tests the "no such published
+// project" branch while still passing the route's UUID format validation.
+const INVALID_TOKEN = 'deadbeef-dead-4bee-8ead-deadbeefcafe'
 const PROJECT_ID = 'clh3p7b1p0001qzrmkf8g4m0i'
 const OTHER_PROJECT_ID = 'clh3p7b1p0001qzrmkf8g4m0j'
 const CHUNK_ID = 'clh4c1a2b0002qzrmkf8g4n1j'
@@ -213,5 +215,21 @@ describe('GET /api/read/[token]/chunks/[chunkId]', () => {
     const body = await res.json()
     expect(body.data.originalText).toBe(fakeChapter.sourceContent)
     expect(body.data.translatedText).toBeNull()
+  })
+
+  // Edge case — chapter exists but sourceContent has not been ingested yet.
+  // Returning 200 with originalText: null would give the reader a blank screen
+  // and no signal. Treat this as "not yet available" → 404 so the caller can
+  // retry or surface a clear message.
+  it('returns 404 when the chapter has not been ingested (sourceContent is null)', async () => {
+    const unIngestedChapter = { ...fakeChapter, sourceContent: null }
+    mockProjectFindFirst.mockResolvedValueOnce(publishedProject)
+    mockChapterFindUnique.mockResolvedValueOnce(unIngestedChapter)
+    const { GET } = await import('@/app/api/read/[token]/chunks/[chunkId]/route')
+    const res = await GET(
+      makeGetRequest(VALID_TOKEN, CHUNK_ID),
+      makeParams(VALID_TOKEN, CHUNK_ID),
+    )
+    expect(res.status).toBe(404)
   })
 })

--- a/bookbridge-next/app/api/read/[token]/chunks/[chunkId]/route.ts
+++ b/bookbridge-next/app/api/read/[token]/chunks/[chunkId]/route.ts
@@ -1,11 +1,11 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { z } from 'zod'
 import prisma from '@/lib/prisma'
-import { getPublishedProject } from '@/lib/public-project'
+import { getPublishedProjectId, tokenSchema } from '@/lib/public-project'
 
 const paramsSchema = z.object({
-  token: z.string().min(1),
-  chunkId: z.string().min(1),
+  token: tokenSchema,
+  chunkId: z.string().min(1).max(256),
 })
 
 export async function GET(
@@ -20,20 +20,31 @@ export async function GET(
 
   const { token, chunkId } = parsed.data
 
-  const project = await getPublishedProject(token)
-  if (!project) {
+  // Run both queries in parallel so "unknown token" and "token ok but chunk
+  // missing/cross-project" take identical wall-clock time — closes the timing
+  // side-channel an attacker could otherwise use to enumerate valid tokens.
+  const [projectId, chapter] = await Promise.all([
+    getPublishedProjectId(token),
+    prisma.chapter.findUnique({
+      where: { id: chunkId },
+      select: { projectId: true, sourceContent: true, translation: true },
+    }),
+  ])
+
+  if (!projectId) {
     return NextResponse.json({ error: 'Invalid token' }, { status: 404 })
   }
 
-  const chapter = await prisma.chapter.findUnique({
-    where: { id: chunkId },
-    select: { projectId: true, sourceContent: true, translation: true },
-  })
-
-  // Cross-project access returns 404 (not 403) so we never confirm the chunk
-  // exists outside the token's project scope.
-  if (!chapter || chapter.projectId !== project.id) {
-    return NextResponse.json({ error: 'Invalid token' }, { status: 404 })
+  // Chunk-level 404: missing, cross-project IDOR, or source not yet ingested.
+  // Different error body ("Not found") than the project-level 404 because the
+  // token is valid here — the ambiguity the enumeration-prevention rule is
+  // about (project existence) is not at risk from this branch.
+  if (
+    !chapter ||
+    chapter.projectId !== projectId ||
+    chapter.sourceContent === null
+  ) {
+    return NextResponse.json({ error: 'Not found' }, { status: 404 })
   }
 
   return NextResponse.json({

--- a/bookbridge-next/app/api/read/[token]/chunks/[chunkId]/route.ts
+++ b/bookbridge-next/app/api/read/[token]/chunks/[chunkId]/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { z } from 'zod'
 import prisma from '@/lib/prisma'
+import { getPublishedProject } from '@/lib/public-project'
 
 const paramsSchema = z.object({
   token: z.string().min(1),
@@ -19,10 +20,7 @@ export async function GET(
 
   const { token, chunkId } = parsed.data
 
-  const project = await prisma.project.findFirst({
-    where: { publicToken: token, isPublic: true },
-    select: { id: true },
-  })
+  const project = await getPublishedProject(token)
   if (!project) {
     return NextResponse.json({ error: 'Invalid token' }, { status: 404 })
   }

--- a/bookbridge-next/app/api/read/[token]/chunks/[chunkId]/route.ts
+++ b/bookbridge-next/app/api/read/[token]/chunks/[chunkId]/route.ts
@@ -1,0 +1,47 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { z } from 'zod'
+import prisma from '@/lib/prisma'
+
+const paramsSchema = z.object({
+  token: z.string().min(1),
+  chunkId: z.string().min(1),
+})
+
+export async function GET(
+  _req: NextRequest,
+  { params }: { params: Promise<{ token: string; chunkId: string }> },
+) {
+  const awaited = await params
+  const parsed = paramsSchema.safeParse(awaited)
+  if (!parsed.success) {
+    return NextResponse.json({ error: 'Invalid request' }, { status: 400 })
+  }
+
+  const { token, chunkId } = parsed.data
+
+  const project = await prisma.project.findFirst({
+    where: { publicToken: token, isPublic: true },
+    select: { id: true },
+  })
+  if (!project) {
+    return NextResponse.json({ error: 'Invalid token' }, { status: 404 })
+  }
+
+  const chapter = await prisma.chapter.findUnique({
+    where: { id: chunkId },
+    select: { projectId: true, sourceContent: true, translation: true },
+  })
+
+  // Cross-project access returns 404 (not 403) so we never confirm the chunk
+  // exists outside the token's project scope.
+  if (!chapter || chapter.projectId !== project.id) {
+    return NextResponse.json({ error: 'Invalid token' }, { status: 404 })
+  }
+
+  return NextResponse.json({
+    data: {
+      originalText: chapter.sourceContent,
+      translatedText: chapter.translation,
+    },
+  })
+}

--- a/bookbridge-next/app/api/read/[token]/route.ts
+++ b/bookbridge-next/app/api/read/[token]/route.ts
@@ -1,8 +1,8 @@
 import { NextRequest, NextResponse } from 'next/server'
-import { z } from 'zod'
-import { getPublishedProject } from '@/lib/public-project'
-
-const tokenSchema = z.string().min(1)
+import {
+  getPublishedProjectWithChapters,
+  tokenSchema,
+} from '@/lib/public-project'
 
 export async function GET(
   _req: NextRequest,
@@ -15,7 +15,7 @@ export async function GET(
     return NextResponse.json({ error: 'Invalid request' }, { status: 400 })
   }
 
-  const project = await getPublishedProject(parsed.data)
+  const project = await getPublishedProjectWithChapters(parsed.data)
   if (!project) {
     return NextResponse.json({ error: 'Invalid token' }, { status: 404 })
   }
@@ -25,6 +25,8 @@ export async function GET(
       title: project.title,
       sourceLanguage: project.sourceLang,
       targetLanguage: project.targetLang,
+      // Intentionally exposed so the reading view can render a progress badge
+      // for projects still translating; no other workflow details are shared.
       status: project.status,
       chapters: project.chapters,
     },

--- a/bookbridge-next/app/api/read/[token]/route.ts
+++ b/bookbridge-next/app/api/read/[token]/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { z } from 'zod'
-import prisma from '@/lib/prisma'
+import { getPublishedProject } from '@/lib/public-project'
 
 const tokenSchema = z.string().min(1)
 
@@ -15,18 +15,7 @@ export async function GET(
     return NextResponse.json({ error: 'Invalid request' }, { status: 400 })
   }
 
-  // Single query gates both existence and publish-state. Unknown token and
-  // unpublished project both return null → identical 404 prevents enumeration.
-  const project = await prisma.project.findFirst({
-    where: { publicToken: parsed.data, isPublic: true },
-    include: {
-      chapters: {
-        orderBy: { number: 'asc' },
-        select: { id: true, number: true, title: true },
-      },
-    },
-  })
-
+  const project = await getPublishedProject(parsed.data)
   if (!project) {
     return NextResponse.json({ error: 'Invalid token' }, { status: 404 })
   }

--- a/bookbridge-next/app/api/read/[token]/route.ts
+++ b/bookbridge-next/app/api/read/[token]/route.ts
@@ -1,0 +1,43 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { z } from 'zod'
+import prisma from '@/lib/prisma'
+
+const tokenSchema = z.string().min(1)
+
+export async function GET(
+  _req: NextRequest,
+  { params }: { params: Promise<{ token: string }> },
+) {
+  const { token } = await params
+
+  const parsed = tokenSchema.safeParse(token)
+  if (!parsed.success) {
+    return NextResponse.json({ error: 'Invalid request' }, { status: 400 })
+  }
+
+  // Single query gates both existence and publish-state. Unknown token and
+  // unpublished project both return null → identical 404 prevents enumeration.
+  const project = await prisma.project.findFirst({
+    where: { publicToken: parsed.data, isPublic: true },
+    include: {
+      chapters: {
+        orderBy: { number: 'asc' },
+        select: { id: true, number: true, title: true },
+      },
+    },
+  })
+
+  if (!project) {
+    return NextResponse.json({ error: 'Invalid token' }, { status: 404 })
+  }
+
+  return NextResponse.json({
+    data: {
+      title: project.title,
+      sourceLanguage: project.sourceLang,
+      targetLanguage: project.targetLang,
+      status: project.status,
+      chapters: project.chapters,
+    },
+  })
+}

--- a/bookbridge-next/lib/__tests__/public-project.test.ts
+++ b/bookbridge-next/lib/__tests__/public-project.test.ts
@@ -1,0 +1,92 @@
+/**
+ * Unit tests for lib/public-project.ts
+ *
+ * The helpers are the single source of truth for the enumeration-prevention
+ * query (WHERE publicToken = token AND isPublic = true). The route-level tests
+ * mock findFirst directly, so without these unit tests there is no coverage
+ * that would catch a caller accidentally dropping the `isPublic: true` filter
+ * and leaking unpublished-project existence.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const mockProjectFindFirst = vi.fn()
+
+vi.mock('@/lib/prisma', () => ({
+  default: {
+    project: {
+      findFirst: (...args: unknown[]) => mockProjectFindFirst(...args),
+    },
+  },
+}))
+
+describe('getPublishedProjectId', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('queries with isPublic=true filter to enforce the enumeration invariant', async () => {
+    mockProjectFindFirst.mockResolvedValueOnce({ id: 'proj_1' })
+    const { getPublishedProjectId } = await import('@/lib/public-project')
+
+    await getPublishedProjectId('some-token')
+
+    expect(mockProjectFindFirst).toHaveBeenCalledTimes(1)
+    const [args] = mockProjectFindFirst.mock.calls[0]
+    expect(args.where).toEqual({
+      publicToken: 'some-token',
+      isPublic: true,
+    })
+  })
+
+  it('returns just the id, not the full project payload', async () => {
+    mockProjectFindFirst.mockResolvedValueOnce({
+      id: 'proj_1',
+      title: 'Secret',
+      ownerId: 'user_1',
+    })
+    const { getPublishedProjectId } = await import('@/lib/public-project')
+
+    const result = await getPublishedProjectId('some-token')
+
+    expect(result).toBe('proj_1')
+  })
+
+  it('returns null when no published project matches', async () => {
+    mockProjectFindFirst.mockResolvedValueOnce(null)
+    const { getPublishedProjectId } = await import('@/lib/public-project')
+
+    const result = await getPublishedProjectId('some-token')
+
+    expect(result).toBeNull()
+  })
+})
+
+describe('getPublishedProjectWithChapters', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('queries with isPublic=true filter and includes chapters ordered by number', async () => {
+    mockProjectFindFirst.mockResolvedValueOnce({ id: 'proj_1', chapters: [] })
+    const { getPublishedProjectWithChapters } = await import(
+      '@/lib/public-project'
+    )
+
+    await getPublishedProjectWithChapters('some-token')
+
+    const [args] = mockProjectFindFirst.mock.calls[0]
+    expect(args.where).toEqual({
+      publicToken: 'some-token',
+      isPublic: true,
+    })
+    expect(args.include.chapters.orderBy).toEqual({ number: 'asc' })
+    // Chapter response must not leak sourceContent/translation at this layer —
+    // that is fetched per-chunk via the dedicated route.
+    expect(args.include.chapters.select).toEqual({
+      id: true,
+      number: true,
+      title: true,
+    })
+  })
+})

--- a/bookbridge-next/lib/public-project.ts
+++ b/bookbridge-next/lib/public-project.ts
@@ -1,9 +1,26 @@
+import { z } from 'zod'
 import prisma from '@/lib/prisma'
+
+// publicToken is minted via crypto.randomUUID() in the project publish flow, so
+// the format is strict — reject anything non-UUID at the edge to shrink the
+// attack surface before the DB is touched.
+export const tokenSchema = z.string().uuid()
 
 // Filters on isPublic=true so unknown tokens and unpublished projects both
 // resolve to null. Callers must return 404 (never 403) on null — a 403 would
 // confirm the project exists and enable enumeration (OWASP A01).
-export async function getPublishedProject(token: string) {
+
+export async function getPublishedProjectId(
+  token: string,
+): Promise<string | null> {
+  const project = await prisma.project.findFirst({
+    where: { publicToken: token, isPublic: true },
+    select: { id: true },
+  })
+  return project?.id ?? null
+}
+
+export async function getPublishedProjectWithChapters(token: string) {
   return prisma.project.findFirst({
     where: { publicToken: token, isPublic: true },
     include: {

--- a/bookbridge-next/lib/public-project.ts
+++ b/bookbridge-next/lib/public-project.ts
@@ -1,0 +1,16 @@
+import prisma from '@/lib/prisma'
+
+// Filters on isPublic=true so unknown tokens and unpublished projects both
+// resolve to null. Callers must return 404 (never 403) on null — a 403 would
+// confirm the project exists and enable enumeration (OWASP A01).
+export async function getPublishedProject(token: string) {
+  return prisma.project.findFirst({
+    where: { publicToken: token, isPublic: true },
+    include: {
+      chapters: {
+        orderBy: { number: 'asc' },
+        select: { id: true, number: true, title: true },
+      },
+    },
+  })
+}

--- a/bookbridge-next/vitest.config.ts
+++ b/bookbridge-next/vitest.config.ts
@@ -8,7 +8,11 @@ export default defineConfig({
     environment: 'jsdom',
     globals: true,
     setupFiles: ['./vitest.setup.ts'],
-    include: ['__tests__/**/*.test.{ts,tsx}', 'app/**/__tests__/**/*.test.{ts,tsx}'],
+    include: [
+      '__tests__/**/*.test.{ts,tsx}',
+      'app/**/__tests__/**/*.test.{ts,tsx}',
+      'lib/**/__tests__/**/*.test.{ts,tsx}',
+    ],
     coverage: {
       provider: 'v8',
       reporter: ['text', 'lcov'],


### PR DESCRIPTION
## Summary
Closes #32

- Add `GET /api/read/[token]` — returns published project metadata (title, source/target language, status, chapter list) for unauthenticated readers
- Add `GET /api/read/[token]/chunks/[chunkId]` — returns `originalText` + `translatedText` for one chapter, scoped to the token's project so cross-project IDOR is blocked
- Extract `lib/public-project.ts#getPublishedProject(token)` so the enumeration-prevention invariant (filter `isPublic=true`, callers must 404 never 403) is defined in one place

## Acceptance Criteria
- [x] `GET /api/read/[token]` returns project metadata when `isPublic=true` and token matches; 404 otherwise
- [x] `GET /api/read/[token]/chunks/[chunkId]` returns `originalText` + `translatedText` for a single chunk
- [x] Both routes require no Clerk authentication (token is the authorization)
- [x] Unpublished projects (`isPublic=false`) return 404 (not 401 or 403)
- [x] Unknown token returns 404 — never leaks whether the project exists
- [x] Response only includes fields needed by the reading view (no internal IDs or owner data)

## C.L.E.A.R. Self-Review
- [x] **Correct** — all 14 red-phase tests pass, including the cross-project IDOR case and the identical-404-body-shape enumeration check
- [x] **Legible** — route handlers are short and linear; the one non-obvious invariant (`isPublic=true` filter for enumeration prevention) has a single-line comment
- [x] **Efficient** — metadata route is a single `findFirst` with included chapters; chunks route is two queries (project auth + chapter fetch) which is inherent to the token→chunk scoping check
- [x] **Abstracted** — shared lookup extracted to `getPublishedProject`; both routes converge on the same 404 shape `{ error: 'Invalid token' }`
- [x] **Risk-aware** — token is treated as opaque (Zod non-empty validation only, Prisma parameterized); no user input reaches the logs; error body uses a generic message that doesn't mention "exist", "found", or "public"

## AI Disclosure
- AI-generated: ~85%
- Tool used: Claude Code (claude-opus-4-7, 1M context)
- Human review: yes — TDD cycle verified (red → green → refactor), all tests checked manually, OWASP A01 enumeration behavior reasoned through and tested