### PR TITLE
chore: add Playwright MCP + move Start Reading button

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -3,6 +3,10 @@
     "glossary-server": {
       "command": "python",
       "args": ["-m", "bookbridge.mcp_servers.glossary_server", "--db", "glossary.db"]
+    },
+    "playwright": {
+      "command": "npx",
+      "args": ["@playwright/mcp@latest"]
     }
   }
 }

--- a/bookbridge-next/app/dashboard/projects/[id]/page.tsx
+++ b/bookbridge-next/app/dashboard/projects/[id]/page.tsx
@@ -45,6 +45,14 @@ export default async function ProjectPage({
             {project.sourceLang} &rarr; {project.targetLang} &middot;{' '}
             {project.chapters.length} chapters
           </p>
+          {project.chapters.length > 0 && (
+            <Link
+              href={`/read/${id}`}
+              className="mt-3 inline-block rounded-lg bg-green-600 px-4 py-2 text-sm font-medium text-white hover:bg-green-700"
+            >
+              Start Reading
+            </Link>
+          )}
         </div>
         <div className="flex gap-2">
           <Link
@@ -54,14 +62,6 @@ export default async function ProjectPage({
             <BookOpen className="mr-1 inline h-4 w-4" />
             Glossary ({project.glossary.length})
           </Link>
-          {project.chapters.length > 0 && (
-            <Link
-              href={`/read/${id}`}
-              className="rounded-lg bg-green-600 px-4 py-2 text-sm font-medium text-white hover:bg-green-700"
-            >
-              Start Reading
-            </Link>
-          )}
           <DeleteProjectButton projectId={project.id} />
         </div>
       </div>


### PR DESCRIPTION
## Summary
- Add Playwright MCP server config to \`.mcp.json\` so Claude Code can drive a live browser for UI verification.
- Move the green **Start Reading** button on the project detail page to sit directly under the title/subtitle; Glossary + Delete stay top-right.

## Test plan
- [x] Verified live in browser via Playwright MCP — screenshot attached to conversation.
- [ ] Reviewer: confirm \`.mcp.json\` change is acceptable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)