### PR TITLE
Fix: add Cancel button and link logo to homepage

### DIFF
--- a/bookbridge-next/app/components/Navbar.tsx
+++ b/bookbridge-next/app/components/Navbar.tsx
@@ -7,7 +7,7 @@ export default function Navbar() {
   return (
     <header className="border-b border-parchment bg-cream">
       <div className="mx-auto flex h-16 max-w-6xl items-center justify-between px-6">
-        <Link href="/dashboard" className="flex items-center gap-3">
+        <Link href="/" className="flex items-center gap-3">
           <div className="flex h-9 w-9 items-center justify-center rounded-lg bg-accent text-white font-serif text-lg font-bold">
             B
           </div>

--- a/bookbridge-next/app/dashboard/new/page.tsx
+++ b/bookbridge-next/app/dashboard/new/page.tsx
@@ -110,23 +110,32 @@ export default function NewProjectPage() {
           </p>
         )}
 
-        <button
-          type="submit"
-          disabled={uploading}
-          className="flex w-full items-center justify-center gap-2 rounded-lg bg-blue-600 px-4 py-2.5 text-sm font-medium text-white hover:bg-blue-700 disabled:opacity-50"
-        >
-          {uploading ? (
-            <>
-              <Loader2 className="h-4 w-4 animate-spin" />
-              Uploading...
-            </>
-          ) : (
-            <>
-              <Upload className="h-4 w-4" />
-              Create Project
-            </>
-          )}
-        </button>
+        <div className="flex gap-3">
+          <button
+            type="button"
+            onClick={() => router.push('/dashboard')}
+            className="flex w-full items-center justify-center rounded-lg border border-zinc-300 px-4 py-2.5 text-sm font-medium text-zinc-700 hover:bg-zinc-50 dark:border-zinc-700 dark:text-zinc-300 dark:hover:bg-zinc-800"
+          >
+            Cancel
+          </button>
+          <button
+            type="submit"
+            disabled={uploading}
+            className="flex w-full items-center justify-center gap-2 rounded-lg bg-blue-600 px-4 py-2.5 text-sm font-medium text-white hover:bg-blue-700 disabled:opacity-50"
+          >
+            {uploading ? (
+              <>
+                <Loader2 className="h-4 w-4 animate-spin" />
+                Uploading...
+              </>
+            ) : (
+              <>
+                <Upload className="h-4 w-4" />
+                Create Project
+              </>
+            )}
+          </button>
+        </div>
       </form>
     </div>
   )


### PR DESCRIPTION
## Changes
- Added Cancel button on New Translation Project page (returns to dashboard)
- BookBridge logo in navbar now links to landing page `/` instead of `/dashboard`

## Test Plan
- [ ] Click BookBridge logo → goes to landing page
- [ ] Click Cancel on new project page → goes back to dashboard

Made with [Cursor](https://cursor.com)