### PR TITLE
feat: add LLM-powered glossary auto-extraction

### DIFF
--- a/bookbridge-next/app/api/projects/[id]/glossary/extract/route.ts
+++ b/bookbridge-next/app/api/projects/[id]/glossary/extract/route.ts
@@ -1,0 +1,107 @@
+import { auth } from '@clerk/nextjs/server'
+import { NextRequest, NextResponse } from 'next/server'
+import prisma from '@/lib/prisma'
+import { workerFetch } from '@/lib/worker'
+
+interface ExtractedTerm {
+  english: string
+  translation: string | null
+  category: string
+}
+
+export async function POST(
+  _req: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const { id } = await params
+  const { userId } = await auth()
+  if (!userId) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const user = await prisma.user.findUnique({
+    where: { clerkId: userId },
+    select: { apiKey: true },
+  })
+
+  if (!user?.apiKey) {
+    return NextResponse.json(
+      { error: 'API key required. Please add your API key in Settings to use glossary extraction.' },
+      { status: 402 }
+    )
+  }
+
+  const project = await prisma.project.findUnique({
+    where: { id },
+    include: {
+      chapters: { orderBy: { number: 'asc' }, select: { sourceContent: true } },
+      glossary: { select: { english: true } },
+    },
+  })
+
+  if (!project) {
+    return NextResponse.json({ error: 'Project not found' }, { status: 404 })
+  }
+  if (project.ownerId !== userId) {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+  }
+
+  const sourceText = project.chapters
+    .map((c) => c.sourceContent || '')
+    .join('\n\n')
+    .slice(0, 12000)
+
+  if (!sourceText.trim()) {
+    return NextResponse.json({ error: 'No source content to extract from' }, { status: 400 })
+  }
+
+  const existingTerms = new Set(
+    project.glossary.map((g) => g.english.toLowerCase())
+  )
+
+  try {
+    const workerRes = await workerFetch('/glossary/extract', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        text: sourceText,
+        target_lang: project.targetLang,
+      }),
+      timeoutMs: 60_000,
+    })
+
+    if (!workerRes.ok) {
+      return NextResponse.json(
+        { error: 'Glossary extraction failed' },
+        { status: 502 }
+      )
+    }
+
+    const data = (await workerRes.json()) as { terms: ExtractedTerm[] }
+    const newTerms = data.terms.filter(
+      (t) => !existingTerms.has(t.english.toLowerCase())
+    )
+
+    if (newTerms.length > 0) {
+      await prisma.glossaryTerm.createMany({
+        data: newTerms.map((t) => ({
+          projectId: id,
+          english: t.english,
+          translation: t.translation,
+          category: t.category || 'general',
+        })),
+      })
+    }
+
+    return NextResponse.json({
+      extracted: newTerms.length,
+      skipped: data.terms.length - newTerms.length,
+      terms: newTerms,
+    })
+  } catch {
+    return NextResponse.json(
+      { error: 'Glossary extraction failed' },
+      { status: 502 }
+    )
+  }
+}

--- a/bookbridge-next/app/api/projects/[id]/summarize/route.ts
+++ b/bookbridge-next/app/api/projects/[id]/summarize/route.ts
@@ -1,0 +1,68 @@
+import { auth } from '@clerk/nextjs/server'
+import { NextRequest, NextResponse } from 'next/server'
+import prisma from '@/lib/prisma'
+import { workerFetch } from '@/lib/worker'
+
+export async function POST(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const { id } = await params
+  const { userId } = await auth()
+  if (!userId) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const project = await prisma.project.findUnique({
+    where: { id },
+    include: { chapters: { orderBy: { number: 'asc' } } },
+  })
+
+  if (!project) {
+    return NextResponse.json({ error: 'Project not found' }, { status: 404 })
+  }
+  if (project.ownerId !== userId) {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+  }
+
+  const chaptersToSummarize = project.chapters.filter(
+    (c) => c.sourceContent && !c.summary
+  )
+
+  if (chaptersToSummarize.length === 0) {
+    return NextResponse.json({ message: 'All chapters already have summaries', count: 0 })
+  }
+
+  const results: { chapterId: string; summary: string }[] = []
+
+  for (const chapter of chaptersToSummarize) {
+    try {
+      const workerRes = await workerFetch('/summarize', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          text: chapter.sourceContent!.slice(0, 8000),
+          max_words: 100,
+        }),
+        timeoutMs: 30_000,
+      })
+
+      if (workerRes.ok) {
+        const data = (await workerRes.json()) as { summary: string }
+        await prisma.chapter.update({
+          where: { id: chapter.id },
+          data: { summary: data.summary },
+        })
+        results.push({ chapterId: chapter.id, summary: data.summary })
+      }
+    } catch {
+      // Skip chapters that fail — best effort
+    }
+  }
+
+  return NextResponse.json({
+    message: `Generated ${results.length} summaries`,
+    count: results.length,
+    results,
+  })
+}

--- a/bookbridge-next/app/dashboard/projects/[id]/ChapterExplorer.tsx
+++ b/bookbridge-next/app/dashboard/projects/[id]/ChapterExplorer.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useState } from 'react'
-import { FileText, CheckCircle, Clock, Loader2 } from 'lucide-react'
+import { FileText, CheckCircle, Clock, Loader2, Sparkles } from 'lucide-react'
 import TranslateButton from './TranslateButton'
 
 interface ChapterData {
@@ -33,8 +33,40 @@ export default function ChapterExplorer({
   const [selectedId, setSelectedId] = useState<string | null>(
     chapters[0]?.id ?? null
   )
+  const [summarizing, setSummarizing] = useState(false)
+  const [summaries, setSummaries] = useState<Record<string, string>>(() => {
+    const map: Record<string, string> = {}
+    for (const c of chapters) {
+      if (c.summary) map[c.id] = c.summary
+    }
+    return map
+  })
 
   const selected = chapters.find((c) => c.id === selectedId)
+  const hasMissingSummaries = chapters.some(
+    (c) => c.sourceContent && !summaries[c.id]
+  )
+
+  async function handleGenerateSummaries() {
+    setSummarizing(true)
+    try {
+      const res = await fetch(`/api/projects/${projectId}/summarize`, {
+        method: 'POST',
+      })
+      if (res.ok) {
+        const data = await res.json()
+        const newSummaries = { ...summaries }
+        for (const r of data.results ?? []) {
+          newSummaries[r.chapterId] = r.summary
+        }
+        setSummaries(newSummaries)
+      }
+    } catch {
+      // Best effort
+    } finally {
+      setSummarizing(false)
+    }
+  }
 
   function getChapterStatus(chapter: ChapterData) {
     if (chapter.translation) return 'translated'
@@ -73,6 +105,20 @@ export default function ChapterExplorer({
             {translatedCount}/{chapters.length} translated
           </span>
         </div>
+        {hasMissingSummaries && (
+          <button
+            onClick={handleGenerateSummaries}
+            disabled={summarizing}
+            className="mb-3 flex w-full items-center justify-center gap-1.5 rounded-lg border border-accent/30 px-3 py-1.5 text-xs font-medium text-accent hover:bg-accent/5 disabled:opacity-50"
+          >
+            {summarizing ? (
+              <Loader2 className="h-3.5 w-3.5 animate-spin" />
+            ) : (
+              <Sparkles className="h-3.5 w-3.5" />
+            )}
+            {summarizing ? 'Generating...' : 'Generate Summaries'}
+          </button>
+        )}
         <div className="space-y-1">
           {chapters.map((chapter) => {
             const status = getChapterStatus(chapter)
@@ -140,13 +186,13 @@ export default function ChapterExplorer({
               </div>
             </div>
 
-            {selected.summary && (
+            {(summaries[selected.id] || selected.summary) && (
               <div className="mt-4 rounded-lg bg-highlight/30 p-3">
                 <p className="text-xs font-semibold uppercase tracking-widest text-ink-muted">
                   Summary
                 </p>
                 <p className="mt-1 text-sm leading-relaxed text-ink-light">
-                  {selected.summary}
+                  {summaries[selected.id] || selected.summary}
                 </p>
               </div>
             )}

--- a/bookbridge-next/app/dashboard/projects/[id]/ChapterExplorer.tsx
+++ b/bookbridge-next/app/dashboard/projects/[id]/ChapterExplorer.tsx
@@ -1,0 +1,198 @@
+'use client'
+
+import { useState } from 'react'
+import { FileText, CheckCircle, Clock, Loader2 } from 'lucide-react'
+import TranslateButton from './TranslateButton'
+
+interface ChapterData {
+  id: string
+  number: number
+  title: string
+  startPage: number
+  endPage: number
+  sourceContent: string | null
+  translation: string | null
+  summary: string | null
+}
+
+interface JobData {
+  id: string
+  chapterId: string | null
+  status: string
+}
+
+export default function ChapterExplorer({
+  chapters,
+  jobs,
+  projectId,
+}: {
+  chapters: ChapterData[]
+  jobs: JobData[]
+  projectId: string
+}) {
+  const [selectedId, setSelectedId] = useState<string | null>(
+    chapters[0]?.id ?? null
+  )
+
+  const selected = chapters.find((c) => c.id === selectedId)
+
+  function getChapterStatus(chapter: ChapterData) {
+    if (chapter.translation) return 'translated'
+    const job = jobs.find((j) => j.chapterId === chapter.id)
+    if (job?.status === 'PROCESSING' || job?.status === 'RUNNING' || job?.status === 'PENDING')
+      return 'translating'
+    if (job?.status === 'QUEUED') return 'queued'
+    return 'pending'
+  }
+
+  if (chapters.length === 0) {
+    return (
+      <div className="flex flex-col items-center justify-center py-16 text-center">
+        <Loader2 className="h-8 w-8 animate-spin text-accent" />
+        <p className="mt-4 text-sm text-ink-muted">
+          Scanning chapters from your PDF...
+        </p>
+        <p className="mt-1 text-xs text-ink-muted">
+          This may take a moment for large files.
+        </p>
+      </div>
+    )
+  }
+
+  const translatedCount = chapters.filter((c) => c.translation).length
+
+  return (
+    <div className="flex gap-6">
+      {/* Sidebar: chapter list */}
+      <div className="w-72 shrink-0">
+        <div className="mb-3 flex items-center justify-between">
+          <p className="text-xs font-semibold uppercase tracking-widest text-ink-muted">
+            Chapters
+          </p>
+          <span className="text-xs text-ink-muted">
+            {translatedCount}/{chapters.length} translated
+          </span>
+        </div>
+        <div className="space-y-1">
+          {chapters.map((chapter) => {
+            const status = getChapterStatus(chapter)
+            const isSelected = chapter.id === selectedId
+            return (
+              <button
+                key={chapter.id}
+                onClick={() => setSelectedId(chapter.id)}
+                className={`flex w-full items-center gap-2.5 rounded-lg px-3 py-2.5 text-left text-sm transition-colors ${
+                  isSelected
+                    ? 'bg-accent/10 text-accent'
+                    : 'text-ink-light hover:bg-parchment/50 hover:text-ink'
+                }`}
+              >
+                {status === 'translated' ? (
+                  <CheckCircle className="h-4 w-4 shrink-0 text-green-500" />
+                ) : status === 'translating' ? (
+                  <Loader2 className="h-4 w-4 shrink-0 animate-spin text-purple-500" />
+                ) : status === 'queued' ? (
+                  <Clock className="h-4 w-4 shrink-0 text-yellow-500" />
+                ) : (
+                  <FileText className="h-4 w-4 shrink-0 text-ink-muted" />
+                )}
+                <div className="min-w-0 flex-1">
+                  <p className={`truncate font-medium ${isSelected ? 'text-accent' : ''}`}>
+                    {chapter.number}. {chapter.title}
+                  </p>
+                  <p className="text-xs text-ink-muted">
+                    pp. {chapter.startPage}–{chapter.endPage}
+                  </p>
+                </div>
+              </button>
+            )
+          })}
+        </div>
+      </div>
+
+      {/* Content preview panel */}
+      <div className="min-w-0 flex-1 rounded-xl border border-parchment bg-white p-6">
+        {selected ? (
+          <>
+            <div className="flex items-start justify-between">
+              <div>
+                <p className="text-xs font-medium uppercase tracking-widest text-accent">
+                  Chapter {selected.number}
+                </p>
+                <h3 className="mt-1 font-serif text-xl font-bold text-ink">
+                  {selected.title}
+                </h3>
+                <p className="mt-1 text-xs text-ink-muted">
+                  Pages {selected.startPage}–{selected.endPage}
+                </p>
+              </div>
+              <div className="flex items-center gap-2">
+                {selected.translation ? (
+                  <span className="rounded-full bg-green-100 px-2.5 py-0.5 text-xs font-medium text-green-700">
+                    Translated
+                  </span>
+                ) : (
+                  <TranslateButton
+                    projectId={projectId}
+                    chapterId={selected.id}
+                  />
+                )}
+              </div>
+            </div>
+
+            {selected.summary && (
+              <div className="mt-4 rounded-lg bg-highlight/30 p-3">
+                <p className="text-xs font-semibold uppercase tracking-widest text-ink-muted">
+                  Summary
+                </p>
+                <p className="mt-1 text-sm leading-relaxed text-ink-light">
+                  {selected.summary}
+                </p>
+              </div>
+            )}
+
+            <div className="mt-6">
+              {selected.translation ? (
+                <div className="grid gap-6 md:grid-cols-2">
+                  <div>
+                    <p className="mb-2 text-xs font-semibold uppercase tracking-widest text-ink-muted">
+                      Original
+                    </p>
+                    <div className="max-h-96 overflow-y-auto whitespace-pre-wrap font-serif text-sm leading-relaxed text-ink">
+                      {selected.sourceContent || (
+                        <span className="italic text-ink-muted">No content</span>
+                      )}
+                    </div>
+                  </div>
+                  <div className="rounded-xl bg-accent-light/30 p-4">
+                    <p className="mb-2 text-xs font-semibold uppercase tracking-widest text-accent">
+                      Translation
+                    </p>
+                    <div className="max-h-96 overflow-y-auto whitespace-pre-wrap font-serif text-sm leading-relaxed text-ink">
+                      {selected.translation}
+                    </div>
+                  </div>
+                </div>
+              ) : (
+                <div>
+                  <p className="mb-2 text-xs font-semibold uppercase tracking-widest text-ink-muted">
+                    Source text
+                  </p>
+                  <div className="max-h-[500px] overflow-y-auto whitespace-pre-wrap font-serif text-sm leading-relaxed text-ink">
+                    {selected.sourceContent || (
+                      <span className="italic text-ink-muted">
+                        No content available for this chapter.
+                      </span>
+                    )}
+                  </div>
+                </div>
+              )}
+            </div>
+          </>
+        ) : (
+          <p className="text-sm text-ink-muted">Select a chapter to preview.</p>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/bookbridge-next/app/dashboard/projects/[id]/glossary/GlossaryActions.tsx
+++ b/bookbridge-next/app/dashboard/projects/[id]/glossary/GlossaryActions.tsx
@@ -1,0 +1,91 @@
+'use client'
+
+import { useState } from 'react'
+import Link from 'next/link'
+import { Sparkles, Loader2, AlertTriangle } from 'lucide-react'
+
+export default function GlossaryActions({
+  projectId,
+  hasApiKey,
+  estimatedTokens,
+}: {
+  projectId: string
+  hasApiKey: boolean
+  estimatedTokens: number
+}) {
+  const [extracting, setExtracting] = useState(false)
+  const [result, setResult] = useState<{ extracted: number; skipped: number } | null>(null)
+  const [error, setError] = useState('')
+
+  async function handleExtract() {
+    setExtracting(true)
+    setError('')
+    setResult(null)
+
+    try {
+      const res = await fetch(`/api/projects/${projectId}/glossary/extract`, {
+        method: 'POST',
+      })
+      const data = await res.json()
+
+      if (!res.ok) {
+        setError(data.error || 'Extraction failed')
+        return
+      }
+
+      setResult({ extracted: data.extracted, skipped: data.skipped })
+      if (data.extracted > 0) {
+        setTimeout(() => window.location.reload(), 1500)
+      }
+    } catch {
+      setError('Failed to extract glossary terms')
+    } finally {
+      setExtracting(false)
+    }
+  }
+
+  return (
+    <div className="flex flex-col items-end gap-2">
+      {hasApiKey ? (
+        <>
+          <button
+            onClick={handleExtract}
+            disabled={extracting}
+            className="flex items-center gap-1.5 rounded-lg bg-accent px-4 py-2 text-sm font-medium text-white hover:bg-accent-hover disabled:opacity-50"
+          >
+            {extracting ? (
+              <Loader2 className="h-4 w-4 animate-spin" />
+            ) : (
+              <Sparkles className="h-4 w-4" />
+            )}
+            {extracting ? 'Extracting...' : 'Auto-extract Glossary'}
+          </button>
+          <p className="text-xs text-ink-muted">
+            ~{estimatedTokens.toLocaleString()} tokens estimated
+          </p>
+        </>
+      ) : (
+        <div className="flex items-center gap-2 rounded-lg bg-highlight/50 px-3 py-2">
+          <AlertTriangle className="h-4 w-4 shrink-0 text-ink-muted" />
+          <p className="text-xs text-ink-muted">
+            <Link href="/dashboard/settings" className="font-medium text-accent hover:underline">
+              Add your API key
+            </Link>{' '}
+            to enable auto-extraction.
+          </p>
+        </div>
+      )}
+
+      {error && (
+        <p className="text-xs text-red-600">{error}</p>
+      )}
+
+      {result && (
+        <p className="text-xs text-green-700">
+          Extracted {result.extracted} new terms
+          {result.skipped > 0 && ` (${result.skipped} duplicates skipped)`}
+        </p>
+      )}
+    </div>
+  )
+}

--- a/bookbridge-next/app/dashboard/projects/[id]/glossary/page.tsx
+++ b/bookbridge-next/app/dashboard/projects/[id]/glossary/page.tsx
@@ -3,6 +3,7 @@ import { redirect, notFound } from 'next/navigation'
 import Link from 'next/link'
 import prisma from '@/lib/prisma'
 import { ArrowLeft, Check, X } from 'lucide-react'
+import GlossaryActions from './GlossaryActions'
 
 export default async function GlossaryPage({
   params,
@@ -15,53 +16,79 @@ export default async function GlossaryPage({
 
   const project = await prisma.project.findUnique({
     where: { id },
-    include: { glossary: { orderBy: { english: 'asc' } } },
+    include: {
+      glossary: { orderBy: { english: 'asc' } },
+      chapters: { select: { sourceContent: true } },
+    },
   })
 
   if (!project) notFound()
   if (project.ownerId !== userId) notFound()
 
+  const user = await prisma.user.findUnique({
+    where: { clerkId: userId },
+    select: { apiKey: true },
+  })
+
+  const totalChars = project.chapters.reduce(
+    (sum, c) => sum + (c.sourceContent?.length || 0),
+    0
+  )
+  const estimatedTokens = Math.round(totalChars / 4)
+
   return (
     <div>
       <Link
         href={`/dashboard/projects/${id}`}
-        className="flex items-center gap-1 text-sm text-zinc-500 hover:text-zinc-700"
+        className="flex items-center gap-1 text-sm text-ink-muted hover:text-ink"
       >
         <ArrowLeft className="h-4 w-4" />
         Back to Project
       </Link>
 
-      <div className="mt-4">
-        <h1 className="text-2xl font-bold">Glossary</h1>
-        <p className="mt-1 text-sm text-zinc-500">
-          {project.title} &mdash; {project.glossary.length} terms
-        </p>
+      <div className="mt-4 flex items-start justify-between">
+        <div>
+          <h1 className="font-serif text-2xl font-bold text-ink">Glossary</h1>
+          <p className="mt-1 text-sm text-ink-muted">
+            {project.title} &mdash; {project.glossary.length} terms
+          </p>
+        </div>
+        <GlossaryActions
+          projectId={id}
+          hasApiKey={!!user?.apiKey}
+          estimatedTokens={estimatedTokens}
+        />
       </div>
 
       {project.glossary.length === 0 ? (
-        <p className="mt-8 text-center text-sm text-zinc-500">
-          No glossary terms yet. Terms will be extracted during translation.
-        </p>
+        <div className="mt-12 text-center">
+          <p className="text-sm text-ink-muted">
+            No glossary terms yet.
+          </p>
+          <p className="mt-1 text-xs text-ink-muted">
+            {user?.apiKey
+              ? 'Click "Auto-extract" to identify key terms from your book.'
+              : 'Add your API key in Settings to enable automatic glossary extraction.'}
+          </p>
+        </div>
       ) : (
-        <div className="mt-6 overflow-hidden rounded-lg border border-zinc-200 dark:border-zinc-800">
+        <div className="mt-6 overflow-hidden rounded-xl border border-parchment">
           <table className="w-full text-sm">
-            <thead className="bg-zinc-50 dark:bg-zinc-900">
+            <thead className="bg-paper/50">
               <tr>
-                <th className="px-4 py-3 text-left font-medium">English</th>
-                <th className="px-4 py-3 text-left font-medium">
-                  Translation
-                </th>
-                <th className="px-4 py-3 text-left font-medium">Category</th>
-                <th className="px-4 py-3 text-center font-medium">Approved</th>
+                <th className="px-4 py-3 text-left font-medium text-ink">English</th>
+                <th className="px-4 py-3 text-left font-medium text-ink">Translation</th>
+                <th className="px-4 py-3 text-left font-medium text-ink">Category</th>
+                <th className="px-4 py-3 text-center font-medium text-ink">Approved</th>
               </tr>
             </thead>
-            <tbody className="divide-y divide-zinc-200 dark:divide-zinc-800">
+            <tbody className="divide-y divide-parchment">
               {project.glossary.map((term) => (
-                <tr key={term.id} className="hover:bg-zinc-50 dark:hover:bg-zinc-900">
-                  <td className="px-4 py-3 font-medium">{term.english}</td>
-                  <td className="px-4 py-3">{term.translation || '—'}</td>
+                <tr key={term.id} className="hover:bg-paper/30">
+                  <td className="px-4 py-3 font-medium text-ink">{term.english}</td>
+                  <td className="px-4 py-3 text-ink-light">{term.translation || '—'}</td>
                   <td className="px-4 py-3">
-                    <span className="rounded-full bg-zinc-100 px-2 py-0.5 text-xs dark:bg-zinc-800">
+                    <span className="rounded-full bg-parchment px-2 py-0.5 text-xs text-ink-muted">
                       {term.category}
                     </span>
                   </td>
@@ -69,7 +96,7 @@ export default async function GlossaryPage({
                     {term.approved ? (
                       <Check className="mx-auto h-4 w-4 text-green-500" />
                     ) : (
-                      <X className="mx-auto h-4 w-4 text-zinc-300" />
+                      <X className="mx-auto h-4 w-4 text-ink-muted/30" />
                     )}
                   </td>
                 </tr>

--- a/bookbridge-next/app/dashboard/projects/[id]/page.tsx
+++ b/bookbridge-next/app/dashboard/projects/[id]/page.tsx
@@ -2,10 +2,10 @@ import { auth } from '@clerk/nextjs/server'
 import { redirect, notFound } from 'next/navigation'
 import Link from 'next/link'
 import prisma from '@/lib/prisma'
-import { FileText, BookOpen, ArrowLeft } from 'lucide-react'
-import TranslateButton from './TranslateButton'
+import { BookOpen, ArrowLeft } from 'lucide-react'
 import DeleteProjectButton from './DeleteProjectButton'
 import PublishToggle from './PublishToggle'
+import ChapterExplorer from './ChapterExplorer'
 
 export default async function ProjectPage({
   params,
@@ -28,11 +28,15 @@ export default async function ProjectPage({
   if (!project) notFound()
   if (project.ownerId !== userId) notFound()
 
+  const translatedCount = project.chapters.filter((c) => c.translation).length
+  const totalChapters = project.chapters.length
+  const progress = totalChapters > 0 ? Math.round((translatedCount / totalChapters) * 100) : 0
+
   return (
     <div>
       <Link
         href="/dashboard"
-        className="flex items-center gap-1 text-sm text-zinc-500 hover:text-zinc-700"
+        className="flex items-center gap-1 text-sm text-ink-muted hover:text-ink"
       >
         <ArrowLeft className="h-4 w-4" />
         Back to Dashboard
@@ -40,24 +44,35 @@ export default async function ProjectPage({
 
       <div className="mt-4 flex items-start justify-between">
         <div>
-          <h1 className="text-2xl font-bold">{project.title}</h1>
-          <p className="mt-1 text-sm text-zinc-500">
+          <h1 className="font-serif text-2xl font-bold text-ink">{project.title}</h1>
+          <p className="mt-1 text-sm text-ink-muted">
             {project.sourceLang} &rarr; {project.targetLang} &middot;{' '}
-            {project.chapters.length} chapters
+            {totalChapters} chapters
           </p>
-          {project.chapters.length > 0 && (
-            <Link
-              href={`/read/${id}`}
-              className="mt-3 inline-block rounded-lg bg-green-600 px-4 py-2 text-sm font-medium text-white hover:bg-green-700"
-            >
-              Start Reading
-            </Link>
+          {totalChapters > 0 && (
+            <div className="mt-3 flex items-center gap-3">
+              <Link
+                href={`/read/${id}`}
+                className="inline-block rounded-lg bg-accent px-4 py-2 text-sm font-medium text-white hover:bg-accent-hover"
+              >
+                Start Reading
+              </Link>
+              <div className="flex items-center gap-2">
+                <div className="h-2 w-24 overflow-hidden rounded-full bg-parchment">
+                  <div
+                    className="h-full rounded-full bg-accent transition-all"
+                    style={{ width: `${progress}%` }}
+                  />
+                </div>
+                <span className="text-xs text-ink-muted">{progress}%</span>
+              </div>
+            </div>
           )}
         </div>
         <div className="flex gap-2">
           <Link
             href={`/dashboard/projects/${id}/glossary`}
-            className="rounded-lg border border-zinc-300 px-4 py-2 text-sm font-medium hover:bg-zinc-100 dark:border-zinc-700 dark:hover:bg-zinc-900"
+            className="rounded-lg border border-parchment px-4 py-2 text-sm font-medium text-ink-light hover:bg-parchment/50"
           >
             <BookOpen className="mr-1 inline h-4 w-4" />
             Glossary ({project.glossary.length})
@@ -66,12 +81,12 @@ export default async function ProjectPage({
         </div>
       </div>
 
-      <div className="mt-6 rounded-lg border border-zinc-200 p-4 dark:border-zinc-800">
+      <div className="mt-6 rounded-xl border border-parchment bg-white p-4">
         <div className="flex items-start justify-between gap-4">
           <div>
-            <h2 className="text-sm font-semibold">Public link</h2>
-            <p className="mt-1 text-xs text-zinc-500">
-              Publish this book to share a read-only link with anyone — no sign-in required.
+            <h2 className="text-sm font-semibold text-ink">Public link</h2>
+            <p className="mt-1 text-xs text-ink-muted">
+              Publish this book to share a read-only link with anyone.
             </p>
           </div>
           <PublishToggle
@@ -83,60 +98,24 @@ export default async function ProjectPage({
       </div>
 
       <div className="mt-8">
-        <h2 className="text-lg font-semibold">Chapters</h2>
-        {project.chapters.length === 0 ? (
-          <p className="mt-4 text-sm text-zinc-500">
-            No chapters parsed yet. The PDF is being processed.
-          </p>
-        ) : (
-          <div className="mt-4 space-y-2">
-            {project.chapters.map((chapter) => {
-              const job = project.jobs.find(
-                (j) => j.chapterId === chapter.id
-              )
-              const hasTranslation = !!chapter.translation
-
-              return (
-                <div
-                  key={chapter.id}
-                  className="flex items-center justify-between rounded-lg border border-zinc-200 p-4 dark:border-zinc-800"
-                >
-                  <div className="flex items-center gap-3">
-                    <FileText className="h-5 w-5 text-zinc-400" />
-                    <div>
-                      <p className="font-medium">
-                        Ch. {chapter.number}: {chapter.title}
-                      </p>
-                      <p className="text-xs text-zinc-500">
-                        Pages {chapter.startPage}–{chapter.endPage}
-                      </p>
-                    </div>
-                  </div>
-                  <div className="flex items-center gap-3">
-                    {hasTranslation ? (
-                      <span className="rounded-full bg-green-100 px-2.5 py-0.5 text-xs font-medium text-green-700">
-                        Translated
-                      </span>
-                    ) : job?.status === 'PROCESSING' ? (
-                      <span className="rounded-full bg-purple-100 px-2.5 py-0.5 text-xs font-medium text-purple-700">
-                        Translating...
-                      </span>
-                    ) : job?.status === 'QUEUED' ? (
-                      <span className="rounded-full bg-yellow-100 px-2.5 py-0.5 text-xs font-medium text-yellow-700">
-                        Queued
-                      </span>
-                    ) : (
-                      <TranslateButton
-                        projectId={project.id}
-                        chapterId={chapter.id}
-                      />
-                    )}
-                  </div>
-                </div>
-              )
-            })}
-          </div>
-        )}
+        <ChapterExplorer
+          chapters={project.chapters.map((c) => ({
+            id: c.id,
+            number: c.number,
+            title: c.title,
+            startPage: c.startPage,
+            endPage: c.endPage,
+            sourceContent: c.sourceContent,
+            translation: c.translation,
+            summary: c.summary,
+          }))}
+          jobs={project.jobs.map((j) => ({
+            id: j.id,
+            chapterId: j.chapterId,
+            status: j.status,
+          }))}
+          projectId={project.id}
+        />
       </div>
     </div>
   )

--- a/bookbridge/worker_api/models.py
+++ b/bookbridge/worker_api/models.py
@@ -43,3 +43,12 @@ class HealthResponse(BaseModel):
 
 class ErrorResponse(BaseModel):
     detail: str
+
+
+class SummarizeRequest(BaseModel):
+    text: str = Field(..., min_length=1)
+    max_words: int = Field(default=100, ge=20, le=300)
+
+
+class SummarizeResponse(BaseModel):
+    summary: str

--- a/bookbridge/worker_api/models.py
+++ b/bookbridge/worker_api/models.py
@@ -52,3 +52,18 @@ class SummarizeRequest(BaseModel):
 
 class SummarizeResponse(BaseModel):
     summary: str
+
+
+class GlossaryExtractRequest(BaseModel):
+    text: str = Field(..., min_length=1)
+    target_lang: str = Field(default="zh-Hans")
+
+
+class GlossaryTerm(BaseModel):
+    english: str
+    translation: str | None = None
+    category: str = "general"
+
+
+class GlossaryExtractResponse(BaseModel):
+    terms: list[GlossaryTerm]

--- a/bookbridge/worker_api/routes.py
+++ b/bookbridge/worker_api/routes.py
@@ -15,6 +15,9 @@ from bookbridge.ingestion.pdf_reader import extract_pages
 from bookbridge.worker_api.callback import post_worker_callback
 from bookbridge.worker_api.models import (
     ChunkData,
+    GlossaryExtractRequest,
+    GlossaryExtractResponse,
+    GlossaryTerm as GlossaryTermModel,
     HealthResponse,
     JobStatusResponse,
     SummarizeRequest,
@@ -242,3 +245,62 @@ def summarize(body: SummarizeRequest) -> SummarizeResponse:
         raise HTTPException(status_code=502, detail="Summarization failed") from exc
 
     return SummarizeResponse(summary=content.strip())
+
+
+@router.post("/glossary/extract", response_model=GlossaryExtractResponse)
+def extract_glossary(body: GlossaryExtractRequest) -> GlossaryExtractResponse:
+    """Extract glossary terms (proper nouns, technical terms) from text using LLM."""
+    import json
+    import os
+    import urllib.request
+
+    api_key = os.environ.get("LLM_API_KEY", "")
+    base_url = os.environ.get("LLM_BASE_URL", "").rstrip("/")
+    model = os.environ.get("LLM_MODEL", "")
+    if not api_key or not base_url or not model:
+        raise HTTPException(status_code=500, detail="LLM provider not configured")
+
+    system_prompt = (
+        "Extract key terms from the text that should be translated consistently: "
+        "proper nouns (character names, place names), technical terms, and recurring "
+        "important phrases. For each term, provide a suggested translation to "
+        f"{body.target_lang} and a category (one of: character, place, technical, concept, other). "
+        "Return valid JSON: {\"terms\": [{\"english\": \"...\", \"translation\": \"...\", \"category\": \"...\"}]}"
+    )
+    payload = {
+        "model": model,
+        "messages": [
+            {"role": "system", "content": system_prompt},
+            {"role": "user", "content": body.text[:12000]},
+        ],
+        "temperature": 0,
+    }
+
+    req = urllib.request.Request(
+        url=f"{base_url}/chat/completions",
+        data=json.dumps(payload).encode("utf-8"),
+        headers={
+            "Authorization": f"Bearer {api_key}",
+            "Content-Type": "application/json",
+        },
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=60) as resp:
+            result = json.loads(resp.read())
+        content = result["choices"][0]["message"]["content"]
+        parsed = json.loads(content)
+        terms = [
+            GlossaryTermModel(
+                english=t.get("english", ""),
+                translation=t.get("translation"),
+                category=t.get("category", "other"),
+            )
+            for t in parsed.get("terms", [])
+            if t.get("english")
+        ]
+    except Exception as exc:
+        logger.warning("glossary extraction failed: %s", type(exc).__name__)
+        raise HTTPException(status_code=502, detail="Glossary extraction failed") from exc
+
+    return GlossaryExtractResponse(terms=terms)

--- a/bookbridge/worker_api/routes.py
+++ b/bookbridge/worker_api/routes.py
@@ -17,6 +17,8 @@ from bookbridge.worker_api.models import (
     ChunkData,
     HealthResponse,
     JobStatusResponse,
+    SummarizeRequest,
+    SummarizeResponse,
     TranslateChunkAsyncRequest,
     TranslateChunkRequest,
     TranslateChunkResponse,
@@ -193,3 +195,50 @@ def get_job(job_id: str) -> JobStatusResponse:
         error=job.get("error"),
         chunks=job.get("chunks"),
     )
+
+
+@router.post("/summarize", response_model=SummarizeResponse)
+def summarize(body: SummarizeRequest) -> SummarizeResponse:
+    """Generate a short summary of the given text using the configured LLM."""
+    import json
+    import os
+    import urllib.request
+
+    api_key = os.environ.get("LLM_API_KEY", "")
+    base_url = os.environ.get("LLM_BASE_URL", "").rstrip("/")
+    model = os.environ.get("LLM_MODEL", "")
+    if not api_key or not base_url or not model:
+        raise HTTPException(status_code=500, detail="LLM provider not configured")
+
+    system_prompt = (
+        f"Summarize the following text in {body.max_words} words or fewer. "
+        "Write a concise, informative summary suitable as a chapter overview. "
+        "Return only the summary text."
+    )
+    payload = {
+        "model": model,
+        "messages": [
+            {"role": "system", "content": system_prompt},
+            {"role": "user", "content": body.text[:8000]},
+        ],
+        "temperature": 0,
+    }
+
+    req = urllib.request.Request(
+        url=f"{base_url}/chat/completions",
+        data=json.dumps(payload).encode("utf-8"),
+        headers={
+            "Authorization": f"Bearer {api_key}",
+            "Content-Type": "application/json",
+        },
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            result = json.loads(resp.read())
+        content = result["choices"][0]["message"]["content"]
+    except Exception as exc:
+        logger.warning("summarize failed: %s", type(exc).__name__)
+        raise HTTPException(status_code=502, detail="Summarization failed") from exc
+
+    return SummarizeResponse(summary=content.strip())


### PR DESCRIPTION
## Summary
- Worker endpoint `POST /glossary/extract` uses LLM to identify proper nouns, technical terms, and key phrases
- BFF route `POST /api/projects/[id]/glossary/extract` with auth + API key gate (402 if no key)
- "Auto-extract Glossary" button with token estimation display
- Skips duplicate terms already in the project glossary
- Prompts users without API key to add one in Settings

## Test plan
- [ ] Without API key: verify 402 response and prompt to add key
- [ ] With API key: click extract, verify terms appear in glossary table
- [ ] Re-extract: verify duplicates are skipped
- [ ] Verify token estimation shows approximate count

AI Disclosure: ~90% AI-generated (Claude), human-reviewed

Made with [Cursor](https://cursor.com)