### PR TITLE
test: add tests for new API routes and fix existing tests for schema changes

### DIFF
--- a/bookbridge-next/__tests__/api/dashboard-start-reading.test.tsx
+++ b/bookbridge-next/__tests__/api/dashboard-start-reading.test.tsx
@@ -34,13 +34,16 @@ vi.mock('next/link', () => ({
   ),
 }))
 
-// Mock lucide-react icons used by the page
 vi.mock('lucide-react', () => ({
   FileText: () => <svg data-testid="icon-file-text" />,
   BookOpen: () => <svg data-testid="icon-book-open" />,
   ArrowLeft: () => <svg data-testid="icon-arrow-left" />,
   Play: () => <svg data-testid="icon-play" />,
   Loader2: () => <svg data-testid="icon-loader" />,
+  CheckCircle: () => <svg data-testid="icon-check-circle" />,
+  Clock: () => <svg data-testid="icon-clock" />,
+  Sparkles: () => <svg data-testid="icon-sparkles" />,
+  PlayCircle: () => <svg data-testid="icon-play-circle" />,
 }))
 
 // Mock TranslateButton (client component — cannot render in jsdom)
@@ -67,7 +70,6 @@ vi.mock(
   })
 )
 
-// Mock PublishToggle (client component — imports lucide icons not stubbed here)
 vi.mock(
   '@/app/dashboard/projects/[id]/PublishToggle',
   () => ({
@@ -75,6 +77,15 @@ vi.mock(
       <button data-testid="publish-toggle" data-project={projectId}>
         Publish
       </button>
+    ),
+  })
+)
+
+vi.mock(
+  '@/app/dashboard/projects/[id]/ChapterExplorer',
+  () => ({
+    default: ({ chapters }: { chapters: { id: string }[] }) => (
+      <div data-testid="chapter-explorer">{chapters.length} chapters loaded</div>
     ),
   })
 )
@@ -116,6 +127,7 @@ const projectWithChapters = {
       pageCount: 10,
       sourceContent: 'Some text.',
       translation: null,
+      summary: null,
     },
   ],
   jobs: [],

--- a/bookbridge-next/__tests__/api/glossary-extract.test.ts
+++ b/bookbridge-next/__tests__/api/glossary-extract.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { NextRequest } from 'next/server'
+
+vi.mock('@clerk/nextjs/server', () => ({
+  auth: vi.fn(),
+  clerkMiddleware: vi.fn(() => vi.fn()),
+  createRouteMatcher: vi.fn(() => vi.fn()),
+}))
+
+const mockUserFindUnique = vi.fn()
+const mockProjectFindUnique = vi.fn()
+const mockGlossaryCreateMany = vi.fn()
+const mockWorkerFetch = vi.fn()
+
+vi.mock('@/lib/prisma', () => ({
+  default: {
+    user: {
+      findUnique: (...args: unknown[]) => mockUserFindUnique(...args),
+    },
+    project: {
+      findUnique: (...args: unknown[]) => mockProjectFindUnique(...args),
+    },
+    glossaryTerm: {
+      createMany: (...args: unknown[]) => mockGlossaryCreateMany(...args),
+    },
+  },
+}))
+
+vi.mock('@/lib/worker', () => ({
+  workerFetch: (...args: unknown[]) => mockWorkerFetch(...args),
+}))
+
+import { auth } from '@clerk/nextjs/server'
+
+const baseUrl = 'http://localhost:3000/api/projects/proj1/glossary/extract'
+
+function makeParams(): Promise<{ id: string }> {
+  return Promise.resolve({ id: 'proj1' })
+}
+
+describe('POST /api/projects/[id]/glossary/extract', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it('returns 401 when unauthenticated', async () => {
+    vi.mocked(auth).mockResolvedValueOnce({ userId: null } as ReturnType<typeof auth> extends Promise<infer T> ? T : never)
+    const { POST } = await import('@/app/api/projects/[id]/glossary/extract/route')
+    const req = new NextRequest(baseUrl, { method: 'POST' })
+    const res = await POST(req, { params: makeParams() })
+    expect(res.status).toBe(401)
+  })
+
+  it('returns 402 when user has no API key', async () => {
+    vi.mocked(auth).mockResolvedValueOnce({ userId: 'user_abc' } as ReturnType<typeof auth> extends Promise<infer T> ? T : never)
+    mockUserFindUnique.mockResolvedValueOnce({ apiKey: null })
+    const { POST } = await import('@/app/api/projects/[id]/glossary/extract/route')
+    const req = new NextRequest(baseUrl, { method: 'POST' })
+    const res = await POST(req, { params: makeParams() })
+    expect(res.status).toBe(402)
+  })
+
+  it('returns 404 when project not found', async () => {
+    vi.mocked(auth).mockResolvedValueOnce({ userId: 'user_abc' } as ReturnType<typeof auth> extends Promise<infer T> ? T : never)
+    mockUserFindUnique.mockResolvedValueOnce({ apiKey: 'sk-test' })
+    mockProjectFindUnique.mockResolvedValueOnce(null)
+    const { POST } = await import('@/app/api/projects/[id]/glossary/extract/route')
+    const req = new NextRequest(baseUrl, { method: 'POST' })
+    const res = await POST(req, { params: makeParams() })
+    expect(res.status).toBe(404)
+  })
+
+  it('extracts glossary terms and skips duplicates', async () => {
+    vi.mocked(auth).mockResolvedValueOnce({ userId: 'user_abc' } as ReturnType<typeof auth> extends Promise<infer T> ? T : never)
+    mockUserFindUnique.mockResolvedValueOnce({ apiKey: 'sk-test' })
+    mockProjectFindUnique.mockResolvedValueOnce({
+      id: 'proj1',
+      ownerId: 'user_abc',
+      targetLang: 'zh-Hans',
+      chapters: [{ sourceContent: 'The Little Prince lived on asteroid B-612.' }],
+      glossary: [{ english: 'Little Prince' }],
+    })
+    mockWorkerFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          terms: [
+            { english: 'Little Prince', translation: '小王子', category: 'character' },
+            { english: 'asteroid B-612', translation: 'B-612小行星', category: 'place' },
+          ],
+        }),
+    })
+    mockGlossaryCreateMany.mockResolvedValueOnce({ count: 1 })
+
+    const { POST } = await import('@/app/api/projects/[id]/glossary/extract/route')
+    const req = new NextRequest(baseUrl, { method: 'POST' })
+    const res = await POST(req, { params: makeParams() })
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.extracted).toBe(1)
+    expect(body.skipped).toBe(1)
+  })
+})

--- a/bookbridge-next/__tests__/api/jobs-async.test.ts
+++ b/bookbridge-next/__tests__/api/jobs-async.test.ts
@@ -48,7 +48,11 @@ const mockJobUpdate = vi.fn()
 const mockJobFindFirst = vi.fn()
 const mockProjectFindUnique = vi.fn()
 const mockChapterFindUnique = vi.fn()
+const mockChapterFindMany = vi.fn()
 const mockChapterUpdate = vi.fn()
+const mockUserFindUnique = vi.fn()
+const mockUserUpdate = vi.fn()
+const mockGlossaryFindMany = vi.fn()
 const mockTransaction = vi.fn()
 
 vi.mock('@/lib/prisma', () => ({
@@ -63,7 +67,15 @@ vi.mock('@/lib/prisma', () => ({
     },
     chapter: {
       findUnique: (...args: unknown[]) => mockChapterFindUnique(...args),
+      findMany: (...args: unknown[]) => mockChapterFindMany(...args),
       update: (...args: unknown[]) => mockChapterUpdate(...args),
+    },
+    user: {
+      findUnique: (...args: unknown[]) => mockUserFindUnique(...args),
+      update: (...args: unknown[]) => mockUserUpdate(...args),
+    },
+    glossaryTerm: {
+      findMany: (...args: unknown[]) => mockGlossaryFindMany(...args),
     },
     $transaction: (...args: unknown[]) => mockTransaction(...args),
   },
@@ -102,8 +114,10 @@ describe('POST /api/jobs — async conversion (issue #61)', () => {
     vi.clearAllMocks()
     vi.resetModules()
     mockJobFindFirst.mockReset()
-    // Default: no existing active job (idempotency check passes through)
     mockJobFindFirst.mockResolvedValue(null)
+    mockUserFindUnique.mockResolvedValue({ apiKey: 'sk-test', freeCharsUsed: 0 })
+    mockChapterFindMany.mockResolvedValue([])
+    mockGlossaryFindMany.mockResolvedValue([])
   })
 
   // -------------------------------------------------------------------------
@@ -152,12 +166,10 @@ describe('POST /api/jobs — async conversion (issue #61)', () => {
       id: CHAPTER_ID,
       sourceContent: SOURCE_TEXT,
       projectId: PROJECT_ID,
+      number: 1,
     })
     mockJobCreate.mockResolvedValueOnce({ id: JOB_ID, status: 'PENDING' })
 
-    // Worker fetch hangs for 30 000 ms — if the route awaits it the test
-    // will time out (Vitest default: 5 000 ms). The only way to return fast
-    // is to NOT await the Worker call.
     mockGlobalFetch.mockImplementation(
       () => new Promise((resolve) => setTimeout(resolve, 30_000))
     )
@@ -197,10 +209,10 @@ describe('POST /api/jobs — async conversion (issue #61)', () => {
       id: CHAPTER_ID,
       sourceContent: SOURCE_TEXT,
       projectId: PROJECT_ID,
+      number: 1,
     })
     mockJobCreate.mockResolvedValueOnce({ id: JOB_ID, status: 'PENDING' })
 
-    // Worker returns 202 immediately (async endpoint)
     mockGlobalFetch.mockResolvedValueOnce(
       new Response(JSON.stringify({ job_id: 'worker-uuid-123' }), {
         status: 202,
@@ -237,6 +249,7 @@ describe('POST /api/jobs — async conversion (issue #61)', () => {
       id: CHAPTER_ID,
       sourceContent: SOURCE_TEXT,
       projectId: PROJECT_ID,
+      number: 1,
     })
     mockJobCreate.mockResolvedValueOnce({ id: JOB_ID, status: 'PENDING' })
     mockGlobalFetch.mockResolvedValueOnce(

--- a/bookbridge-next/__tests__/api/settings.test.ts
+++ b/bookbridge-next/__tests__/api/settings.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { NextRequest } from 'next/server'
+
+vi.mock('@clerk/nextjs/server', () => ({
+  auth: vi.fn(),
+  clerkMiddleware: vi.fn(() => vi.fn()),
+  createRouteMatcher: vi.fn(() => vi.fn()),
+}))
+
+const mockFindUnique = vi.fn()
+const mockUpsert = vi.fn()
+
+vi.mock('@/lib/prisma', () => ({
+  default: {
+    user: {
+      findUnique: (...args: unknown[]) => mockFindUnique(...args),
+      upsert: (...args: unknown[]) => mockUpsert(...args),
+    },
+  },
+}))
+
+import { auth } from '@clerk/nextjs/server'
+
+const baseUrl = 'http://localhost:3000/api/settings'
+
+describe('GET /api/settings', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it('returns 401 when unauthenticated', async () => {
+    vi.mocked(auth).mockResolvedValueOnce({ userId: null } as ReturnType<typeof auth> extends Promise<infer T> ? T : never)
+    const { GET } = await import('@/app/api/settings/route')
+    const res = await GET()
+    expect(res.status).toBe(401)
+  })
+
+  it('returns user settings when authenticated', async () => {
+    vi.mocked(auth).mockResolvedValueOnce({ userId: 'user_123' } as ReturnType<typeof auth> extends Promise<infer T> ? T : never)
+    mockFindUnique.mockResolvedValueOnce({
+      apiProvider: 'openai',
+      apiBaseUrl: null,
+      freeCharsUsed: 500,
+      apiKey: 'sk-test',
+    })
+    const { GET } = await import('@/app/api/settings/route')
+    const res = await GET()
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.hasApiKey).toBe(true)
+    expect(body.freeCharsUsed).toBe(500)
+    expect(body.apiProvider).toBe('openai')
+  })
+
+  it('returns defaults when user not found in DB', async () => {
+    vi.mocked(auth).mockResolvedValueOnce({ userId: 'user_new' } as ReturnType<typeof auth> extends Promise<infer T> ? T : never)
+    mockFindUnique.mockResolvedValueOnce(null)
+    const { GET } = await import('@/app/api/settings/route')
+    const res = await GET()
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.hasApiKey).toBe(false)
+    expect(body.freeCharsUsed).toBe(0)
+  })
+})
+
+describe('PATCH /api/settings', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it('returns 401 when unauthenticated', async () => {
+    vi.mocked(auth).mockResolvedValueOnce({ userId: null } as ReturnType<typeof auth> extends Promise<infer T> ? T : never)
+    const { PATCH } = await import('@/app/api/settings/route')
+    const req = new NextRequest(baseUrl, {
+      method: 'PATCH',
+      body: JSON.stringify({ apiProvider: 'claude' }),
+      headers: { 'Content-Type': 'application/json' },
+    })
+    const res = await PATCH(req)
+    expect(res.status).toBe(401)
+  })
+
+  it('updates settings successfully', async () => {
+    vi.mocked(auth).mockResolvedValueOnce({ userId: 'user_123' } as ReturnType<typeof auth> extends Promise<infer T> ? T : never)
+    mockUpsert.mockResolvedValueOnce({
+      apiProvider: 'claude',
+      apiBaseUrl: null,
+      freeCharsUsed: 0,
+      apiKey: 'sk-new',
+    })
+    const { PATCH } = await import('@/app/api/settings/route')
+    const req = new NextRequest(baseUrl, {
+      method: 'PATCH',
+      body: JSON.stringify({ apiProvider: 'claude', apiKey: 'sk-new' }),
+      headers: { 'Content-Type': 'application/json' },
+    })
+    const res = await PATCH(req)
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.apiProvider).toBe('claude')
+    expect(body.hasApiKey).toBe(true)
+  })
+
+  it('returns 400 for invalid body', async () => {
+    vi.mocked(auth).mockResolvedValueOnce({ userId: 'user_123' } as ReturnType<typeof auth> extends Promise<infer T> ? T : never)
+    const { PATCH } = await import('@/app/api/settings/route')
+    const req = new NextRequest(baseUrl, {
+      method: 'PATCH',
+      body: JSON.stringify({ apiProvider: 'invalid_provider' }),
+      headers: { 'Content-Type': 'application/json' },
+    })
+    const res = await PATCH(req)
+    expect(res.status).toBe(400)
+  })
+})

--- a/bookbridge-next/__tests__/api/summarize.test.ts
+++ b/bookbridge-next/__tests__/api/summarize.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { NextRequest } from 'next/server'
+
+vi.mock('@clerk/nextjs/server', () => ({
+  auth: vi.fn(),
+  clerkMiddleware: vi.fn(() => vi.fn()),
+  createRouteMatcher: vi.fn(() => vi.fn()),
+}))
+
+const mockProjectFindUnique = vi.fn()
+const mockChapterUpdate = vi.fn()
+const mockWorkerFetch = vi.fn()
+
+vi.mock('@/lib/prisma', () => ({
+  default: {
+    project: {
+      findUnique: (...args: unknown[]) => mockProjectFindUnique(...args),
+    },
+    chapter: {
+      update: (...args: unknown[]) => mockChapterUpdate(...args),
+    },
+  },
+}))
+
+vi.mock('@/lib/worker', () => ({
+  workerFetch: (...args: unknown[]) => mockWorkerFetch(...args),
+}))
+
+import { auth } from '@clerk/nextjs/server'
+
+const baseUrl = 'http://localhost:3000/api/projects/proj1/summarize'
+
+function makeParams(): Promise<{ id: string }> {
+  return Promise.resolve({ id: 'proj1' })
+}
+
+describe('POST /api/projects/[id]/summarize', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it('returns 401 when unauthenticated', async () => {
+    vi.mocked(auth).mockResolvedValueOnce({ userId: null } as ReturnType<typeof auth> extends Promise<infer T> ? T : never)
+    const { POST } = await import('@/app/api/projects/[id]/summarize/route')
+    const req = new NextRequest(baseUrl, { method: 'POST' })
+    const res = await POST(req, { params: makeParams() })
+    expect(res.status).toBe(401)
+  })
+
+  it('returns 404 when project not found', async () => {
+    vi.mocked(auth).mockResolvedValueOnce({ userId: 'user_abc' } as ReturnType<typeof auth> extends Promise<infer T> ? T : never)
+    mockProjectFindUnique.mockResolvedValueOnce(null)
+    const { POST } = await import('@/app/api/projects/[id]/summarize/route')
+    const req = new NextRequest(baseUrl, { method: 'POST' })
+    const res = await POST(req, { params: makeParams() })
+    expect(res.status).toBe(404)
+  })
+
+  it('returns 403 when user does not own project', async () => {
+    vi.mocked(auth).mockResolvedValueOnce({ userId: 'user_abc' } as ReturnType<typeof auth> extends Promise<infer T> ? T : never)
+    mockProjectFindUnique.mockResolvedValueOnce({
+      id: 'proj1',
+      ownerId: 'user_other',
+      chapters: [],
+    })
+    const { POST } = await import('@/app/api/projects/[id]/summarize/route')
+    const req = new NextRequest(baseUrl, { method: 'POST' })
+    const res = await POST(req, { params: makeParams() })
+    expect(res.status).toBe(403)
+  })
+
+  it('returns count 0 when all chapters have summaries', async () => {
+    vi.mocked(auth).mockResolvedValueOnce({ userId: 'user_abc' } as ReturnType<typeof auth> extends Promise<infer T> ? T : never)
+    mockProjectFindUnique.mockResolvedValueOnce({
+      id: 'proj1',
+      ownerId: 'user_abc',
+      chapters: [
+        { id: 'ch1', sourceContent: 'text', summary: 'existing summary' },
+      ],
+    })
+    const { POST } = await import('@/app/api/projects/[id]/summarize/route')
+    const req = new NextRequest(baseUrl, { method: 'POST' })
+    const res = await POST(req, { params: makeParams() })
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.count).toBe(0)
+  })
+
+  it('generates summaries for chapters without them', async () => {
+    vi.mocked(auth).mockResolvedValueOnce({ userId: 'user_abc' } as ReturnType<typeof auth> extends Promise<infer T> ? T : never)
+    mockProjectFindUnique.mockResolvedValueOnce({
+      id: 'proj1',
+      ownerId: 'user_abc',
+      chapters: [
+        { id: 'ch1', sourceContent: 'Chapter one content', summary: null },
+      ],
+    })
+    mockWorkerFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve({ summary: 'A summary of chapter one.' }),
+    })
+    mockChapterUpdate.mockResolvedValueOnce({})
+
+    const { POST } = await import('@/app/api/projects/[id]/summarize/route')
+    const req = new NextRequest(baseUrl, { method: 'POST' })
+    const res = await POST(req, { params: makeParams() })
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.count).toBe(1)
+    expect(body.results[0].summary).toBe('A summary of chapter one.')
+  })
+})

--- a/bookbridge-next/__tests__/api/translate-batch.test.ts
+++ b/bookbridge-next/__tests__/api/translate-batch.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { NextRequest } from 'next/server'
+
+vi.mock('@clerk/nextjs/server', () => ({
+  auth: vi.fn(),
+  clerkMiddleware: vi.fn(() => vi.fn()),
+  createRouteMatcher: vi.fn(() => vi.fn()),
+}))
+
+const mockProjectFindUnique = vi.fn()
+const mockChapterFindMany = vi.fn()
+
+vi.mock('@/lib/prisma', () => ({
+  default: {
+    project: {
+      findUnique: (...args: unknown[]) => mockProjectFindUnique(...args),
+    },
+    chapter: {
+      findMany: (...args: unknown[]) => mockChapterFindMany(...args),
+    },
+  },
+}))
+
+import { auth } from '@clerk/nextjs/server'
+
+const baseUrl = 'http://localhost:3000/api/projects/proj1/translate-batch'
+
+function makeParams(): Promise<{ id: string }> {
+  return Promise.resolve({ id: 'proj1' })
+}
+
+describe('GET /api/projects/[id]/translate-batch', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it('returns 401 when unauthenticated', async () => {
+    vi.mocked(auth).mockResolvedValueOnce({ userId: null } as ReturnType<typeof auth> extends Promise<infer T> ? T : never)
+    const { GET } = await import('@/app/api/projects/[id]/translate-batch/route')
+    const req = new NextRequest(baseUrl)
+    const res = await GET(req, { params: makeParams() })
+    expect(res.status).toBe(401)
+  })
+
+  it('returns 404 when project not found', async () => {
+    vi.mocked(auth).mockResolvedValueOnce({ userId: 'user_abc' } as ReturnType<typeof auth> extends Promise<infer T> ? T : never)
+    mockProjectFindUnique.mockResolvedValueOnce(null)
+    const { GET } = await import('@/app/api/projects/[id]/translate-batch/route')
+    const req = new NextRequest(baseUrl)
+    const res = await GET(req, { params: makeParams() })
+    expect(res.status).toBe(404)
+  })
+
+  it('returns untranslated chapters', async () => {
+    vi.mocked(auth).mockResolvedValueOnce({ userId: 'user_abc' } as ReturnType<typeof auth> extends Promise<infer T> ? T : never)
+    mockProjectFindUnique.mockResolvedValueOnce({ ownerId: 'user_abc' })
+    mockChapterFindMany.mockResolvedValueOnce([
+      { id: 'ch1', number: 1, title: 'One', translation: 'Translated', sourceContent: 'text' },
+      { id: 'ch2', number: 2, title: 'Two', translation: null, sourceContent: 'text' },
+      { id: 'ch3', number: 3, title: 'Three', translation: null, sourceContent: null },
+    ])
+
+    const { GET } = await import('@/app/api/projects/[id]/translate-batch/route')
+    const req = new NextRequest(baseUrl)
+    const res = await GET(req, { params: makeParams() })
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.total).toBe(3)
+    expect(body.translated).toBe(1)
+    expect(body.untranslated).toHaveLength(1)
+    expect(body.untranslated[0].id).toBe('ch2')
+  })
+})

--- a/bookbridge-next/__tests__/read-token-page.test.tsx
+++ b/bookbridge-next/__tests__/read-token-page.test.tsx
@@ -34,6 +34,17 @@ vi.mock('@/lib/prisma', () => ({
   default: { project: { findUnique: vi.fn() } },
 }))
 
+vi.mock('@/app/read/[id]/ReaderView', () => ({
+  default: ({ title, chapters }: { title: string; chapters: { number: number; title: string }[] }) => (
+    <div>
+      <h1>{title}</h1>
+      {chapters.map((ch) => (
+        <div key={ch.number}>Chapter {ch.number}: {ch.title}</div>
+      ))}
+    </div>
+  ),
+}))
+
 const mockGetPublished = vi.fn()
 // Use importOriginal so the real `tokenSchema` (z.string().uuid()) is
 // exposed — the page now dispatches on it, so stubbing it out would break


### PR DESCRIPTION
## Summary
- 4 new test files: settings, summarize, glossary-extract, translate-batch (18 new tests)
- Fixed jobs-async tests to mock new user/chapter/glossary dependencies from context-aware translation
- Fixed dashboard test with updated lucide-react icon mocks and ChapterExplorer mock
- Fixed read-token-page test by mocking client-side ReaderView component
- All 137 tests passing across 23 test files

## Test plan
- [x] `npx vitest run` — all 137 tests pass
- [ ] CI pipeline runs green on push

AI Disclosure: ~90% AI-generated (Claude), human-reviewed

Made with [Cursor](https://cursor.com)