### PR TITLE
fix: resolve stuck translations, glossary extraction, and free-tier UX

### DIFF
--- a/bookbridge-next/app/api/jobs/route.ts
+++ b/bookbridge-next/app/api/jobs/route.ts
@@ -82,15 +82,23 @@ export async function POST(req: NextRequest) {
     )
   }
 
+  const STALE_THRESHOLD_MS = 5 * 60 * 1000
   const existingJob = await prisma.translationJob.findFirst({
     where: { chapterId, status: { in: [...ACTIVE_JOB_STATUSES] } },
-    select: { id: true, status: true },
+    select: { id: true, status: true, createdAt: true },
   })
   if (existingJob) {
-    return NextResponse.json(
-      { id: existingJob.id, status: existingJob.status, error: 'Job already exists for this chapter' },
-      { status: 409 }
-    )
+    const age = Date.now() - new Date(existingJob.createdAt).getTime()
+    if (age < STALE_THRESHOLD_MS) {
+      return NextResponse.json(
+        { id: existingJob.id, status: existingJob.status, error: 'Translation is already in progress for this chapter' },
+        { status: 409 }
+      )
+    }
+    await prisma.translationJob.update({
+      where: { id: existingJob.id },
+      data: { status: 'FAILED', error: 'Timed out — retrying' },
+    })
   }
 
   // Build context from adjacent chapter summaries + project glossary

--- a/bookbridge-next/app/api/projects/[id]/glossary/extract/route.ts
+++ b/bookbridge-next/app/api/projects/[id]/glossary/extract/route.ts
@@ -20,14 +20,10 @@ export async function POST(
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
   }
 
-  const user = await prisma.user.findUnique({
-    where: { clerkId: userId },
-    select: { apiKey: true },
-  })
-
-  if (!user?.apiKey) {
+  const llmCreds = await getUserLLMCredentials(userId)
+  if (!llmCreds) {
     return NextResponse.json(
-      { error: 'API key required. Please add your API key in Settings to use glossary extraction.' },
+      { error: 'No LLM API key available. Please add your API key in Settings to use glossary extraction.' },
       { status: 402 }
     )
   }
@@ -59,8 +55,6 @@ export async function POST(
   const existingTerms = new Set(
     project.glossary.map((g) => g.english.toLowerCase())
   )
-
-  const llmCreds = await getUserLLMCredentials(userId)
 
   try {
     const workerRes = await workerFetch('/glossary/extract', {

--- a/bookbridge-next/app/dashboard/projects/[id]/ChapterExplorer.tsx
+++ b/bookbridge-next/app/dashboard/projects/[id]/ChapterExplorer.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useState } from 'react'
+import Link from 'next/link'
 import { FileText, CheckCircle, Clock, Loader2, Sparkles, PlayCircle } from 'lucide-react'
 import TranslateButton from './TranslateButton'
 import { pollJob } from '@/lib/jobPoll'
@@ -45,6 +46,7 @@ export default function ChapterExplorer({
 
   const [batchTranslating, setBatchTranslating] = useState(false)
   const [batchProgress, setBatchProgress] = useState({ done: 0, total: 0 })
+  const [batchError, setBatchError] = useState<string | null>(null)
 
   const selected = chapters.find((c) => c.id === selectedId)
   const hasMissingSummaries = chapters.some(
@@ -57,6 +59,7 @@ export default function ChapterExplorer({
   async function handleBatchTranslate() {
     if (untranslatedChapters.length === 0) return
     setBatchTranslating(true)
+    setBatchError(null)
     setBatchProgress({ done: 0, total: untranslatedChapters.length })
 
     for (let i = 0; i < untranslatedChapters.length; i++) {
@@ -67,6 +70,11 @@ export default function ChapterExplorer({
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({ projectId, chapterId: ch.id }),
         })
+        if (res.status === 402) {
+          const errBody = await res.json().catch(() => ({}))
+          setBatchError(errBody.error || 'Free tier limit reached.')
+          break
+        }
         if (res.ok) {
           const body = await res.json()
           if (body.id) {
@@ -80,7 +88,7 @@ export default function ChapterExplorer({
     }
 
     setBatchTranslating(false)
-    window.location.reload()
+    if (!batchError) window.location.reload()
   }
 
   async function handleGenerateSummaries() {
@@ -160,6 +168,17 @@ export default function ChapterExplorer({
                 </>
               )}
             </button>
+          )}
+          {batchError && (
+            <div className="rounded-lg bg-red-50 p-2.5 text-xs text-red-600">
+              <p>{batchError}</p>
+              <Link
+                href="/dashboard/settings"
+                className="mt-1 inline-block font-medium text-accent hover:underline"
+              >
+                Go to Settings to add your API key &rarr;
+              </Link>
+            </div>
           )}
           {hasMissingSummaries && (
             <button

--- a/bookbridge-next/app/dashboard/projects/[id]/TranslateButton.tsx
+++ b/bookbridge-next/app/dashboard/projects/[id]/TranslateButton.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useEffect, useRef, useState } from 'react'
+import Link from 'next/link'
 import { Loader2, Play } from 'lucide-react'
 import { pollJob } from '@/lib/jobPoll'
 
@@ -20,6 +21,7 @@ export default function TranslateButton({
 }) {
   const [loading, setLoading] = useState(false)
   const [errorMsg, setErrorMsg] = useState<string | null>(null)
+  const [showSettingsLink, setShowSettingsLink] = useState(false)
   const [elapsedMs, setElapsedMs] = useState(0)
   const abortRef = useRef<AbortController | null>(null)
 
@@ -37,6 +39,7 @@ export default function TranslateButton({
   async function handleTranslate() {
     setLoading(true)
     setErrorMsg(null)
+    setShowSettingsLink(false)
     setElapsedMs(0)
 
     try {
@@ -48,7 +51,8 @@ export default function TranslateButton({
       if (!res.ok) {
         const errBody = await res.json().catch(() => ({}))
         if (res.status === 402) {
-          setErrorMsg(errBody.error || 'Free tier limit reached. Add your API key in Settings.')
+          setErrorMsg(errBody.error || 'Free tier limit reached.')
+          setShowSettingsLink(true)
         } else {
           setErrorMsg(errBody.error || 'Translation failed. Please try again.')
         }
@@ -95,9 +99,17 @@ export default function TranslateButton({
         {label}
       </button>
       {errorMsg && (
-        <p role="alert" className="text-xs text-red-600">
-          {errorMsg}
-        </p>
+        <div role="alert" className="text-xs text-red-600">
+          <p>{errorMsg}</p>
+          {showSettingsLink && (
+            <Link
+              href="/dashboard/settings"
+              className="mt-1 inline-block font-medium text-accent hover:underline"
+            >
+              Go to Settings to add your API key &rarr;
+            </Link>
+          )}
+        </div>
       )}
     </div>
   )

--- a/bookbridge-next/app/dashboard/projects/[id]/glossary/page.tsx
+++ b/bookbridge-next/app/dashboard/projects/[id]/glossary/page.tsx
@@ -30,6 +30,8 @@ export default async function GlossaryPage({
     select: { apiKey: true },
   })
 
+  const hasLLMAccess = !!user?.apiKey || !!process.env.BUILTIN_LLM_API_KEY
+
   const totalChars = project.chapters.reduce(
     (sum, c) => sum + (c.sourceContent?.length || 0),
     0
@@ -55,7 +57,7 @@ export default async function GlossaryPage({
         </div>
         <GlossaryActions
           projectId={id}
-          hasApiKey={!!user?.apiKey}
+          hasApiKey={hasLLMAccess}
           estimatedTokens={estimatedTokens}
         />
       </div>
@@ -66,7 +68,7 @@ export default async function GlossaryPage({
             No glossary terms yet.
           </p>
           <p className="mt-1 text-xs text-ink-muted">
-            {user?.apiKey
+            {hasLLMAccess
               ? 'Click "Auto-extract" to identify key terms from your book.'
               : 'Add your API key in Settings to enable automatic glossary extraction.'}
           </p>


### PR DESCRIPTION
## Summary
- Auto-expire stale PENDING/RUNNING jobs (>5 min) so users can retry translations that silently failed
- Fix glossary extraction: use built-in LLM key fallback instead of requiring user's own API key
- Show "Go to Settings" link when free-tier limit is reached (both single and batch translate)

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `npx vitest run` — all 137 tests pass
- [ ] Manual: click Translate on a chapter that previously got stuck → should auto-expire and retry
- [ ] Manual: click Auto-extract Glossary without own API key → should use built-in key
- [ ] Manual: exhaust free tier → see Settings link in error message

AI Disclosure: ~90% AI-generated (Claude), human-reviewed

Made with [Cursor](https://cursor.com)