### PR TITLE
fix(ci): resolve all lint errors to green CI checks

### DIFF
--- a/bookbridge-next/__tests__/api/projects.test.ts
+++ b/bookbridge-next/__tests__/api/projects.test.ts
@@ -1,5 +1,4 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { NextRequest } from 'next/server'
 
 vi.mock('@clerk/nextjs/server', () => ({
   auth: vi.fn(),

--- a/bookbridge-next/app/read/[id]/ReaderView.tsx
+++ b/bookbridge-next/app/read/[id]/ReaderView.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState, useEffect, useMemo } from 'react'
+import { useState, useMemo } from 'react'
 import Link from 'next/link'
 import { CheckCircle, FileText, Search, Download, X } from 'lucide-react'
 
@@ -34,16 +34,16 @@ export default function ReaderView({
   chapters: ChapterData[]
   isDemo?: boolean
 }) {
-  const [mode, setMode] = useState<ViewMode>('bilingual')
-  const [searchQuery, setSearchQuery] = useState('')
-  const [searchOpen, setSearchOpen] = useState(false)
-
-  useEffect(() => {
+  const [mode, setMode] = useState<ViewMode>(() => {
+    if (typeof window === 'undefined') return 'bilingual'
     const saved = localStorage.getItem('bookbridge-reader-mode')
     if (saved === 'bilingual' || saved === 'translation' || saved === 'source') {
-      setMode(saved)
+      return saved
     }
-  }, [])
+    return 'bilingual'
+  })
+  const [searchQuery, setSearchQuery] = useState('')
+  const [searchOpen, setSearchOpen] = useState(false)
 
   function handleModeChange(newMode: ViewMode) {
     setMode(newMode)

--- a/bookbridge/worker_api/routes.py
+++ b/bookbridge/worker_api/routes.py
@@ -17,7 +17,6 @@ from bookbridge.worker_api.models import (
     ChunkData,
     GlossaryExtractRequest,
     GlossaryExtractResponse,
-    GlossaryTerm as GlossaryTermModel,
     HealthResponse,
     JobStatusResponse,
     SummarizeRequest,
@@ -25,6 +24,9 @@ from bookbridge.worker_api.models import (
     TranslateChunkAsyncRequest,
     TranslateChunkRequest,
     TranslateChunkResponse,
+)
+from bookbridge.worker_api.models import (
+    GlossaryTerm as GlossaryTermModel,
 )
 
 logger = logging.getLogger(__name__)
@@ -276,7 +278,8 @@ def extract_glossary(body: GlossaryExtractRequest) -> GlossaryExtractResponse:
         "proper nouns (character names, place names), technical terms, and recurring "
         "important phrases. For each term, provide a suggested translation to "
         f"{body.target_lang} and a category (one of: character, place, technical, concept, other). "
-        "Return valid JSON: {\"terms\": [{\"english\": \"...\", \"translation\": \"...\", \"category\": \"...\"}]}"
+        'Return valid JSON: {"terms": [{"english": "...", '
+        '"translation": "...", "category": "..."}]}'
     )
     try:
         content = chat_completion(


### PR DESCRIPTION
## Summary
- **Python ruff I001**: sort import block in `worker_api/routes.py` (auto-fixed by `ruff --fix`)
- **Python ruff E501**: break long glossary prompt string under 100-char limit
- **ESLint `react-hooks/set-state-in-effect`**: replace `useEffect` + `setState` with lazy `useState` initializer in `ReaderView.tsx`
- **ESLint `no-unused-vars`**: remove unused `NextRequest` import in `projects.test.ts`

These 4 errors were causing the **Python tests** and **Next.js — lint, typecheck, tests** CI jobs to fail on every PR merge to main.

## Test plan
- [ ] CI "Python tests" job passes (ruff check clean)
- [ ] CI "Next.js — lint, typecheck, tests" job passes (ESLint + tsc + vitest)
- [ ] CI "Playwright E2E" job passes (depends on nextjs job)


Made with [Cursor](https://cursor.com)